### PR TITLE
fix: use exact date instead of duration for incentives setup

### DIFF
--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -603,7 +603,7 @@ export enum TransferStrategy {
 
 export interface RewardsConfigInput {
   emissionPerSecond: BigNumberish;
-  duration: number;
+  distributionEnd: BigNumberish;
   reserve: string;
   incentivizedToken: AssetType;
   reward: tEthereumAddress;

--- a/markets/hydration/index.ts
+++ b/markets/hydration/index.ts
@@ -20,8 +20,6 @@ import {
 import { tokenAddress } from "./helpers";
 import { ZERO_ADDRESS } from "../../helpers";
 
-const SECONDS_PER_DAY = 86400;
-
 export const HydrationConfig: IAaveConfiguration = {
   ...AaveMarket,
   MarketId: "Hydration Market",
@@ -117,9 +115,8 @@ export const HydrationConfig: IAaveConfiguration = {
     [eHydrationNetwork.hydration]: {
       GDOT: [
         {
-          //13320*10^18/(13w*7*86400)
           emissionPerSecond: BigNumber.from("1694139194139194").mul("2"),
-          duration: 7862400,
+          distributionEnd: Date.parse("11 Jul 2025 14:24:36 GMT") / 1000,
           reserve: "2-Pool-GDOT",
           incentivizedToken: AssetType.AToken,
           reward: tokenAddress(69),
@@ -128,9 +125,8 @@ export const HydrationConfig: IAaveConfiguration = {
           emissionAdmin: POOL_ADMIN[eHydrationNetwork.hydration],
         },
         {
-          //214,285*10^12/(90*86400)
           emissionPerSecond: BigNumber.from("27557227366"),
-          duration: 90 * SECONDS_PER_DAY + 2 * SECONDS_PER_DAY, //2 days buffer for voting
+          distributionEnd: Date.parse("30 Jul 2025 17:52:36 GMT") / 1000,
           reserve: "2-Pool-GDOT",
           incentivizedToken: AssetType.AToken,
           reward: tokenAddress(14),
@@ -139,9 +135,8 @@ export const HydrationConfig: IAaveConfiguration = {
           emissionAdmin: POOL_ADMIN[eHydrationNetwork.hydration],
         },
         {
-          //2,222,222*10^12/(90*86400)
           emissionPerSecond: BigNumber.from("285779578189"),
-          duration: 90 * SECONDS_PER_DAY + 2 * SECONDS_PER_DAY, //2 days buffer for voting
+          distributionEnd: Date.parse("30 Jul 2025 17:52:36 GMT") / 1000,
           reserve: "2-Pool-GDOT",
           incentivizedToken: AssetType.AToken,
           reward: tokenAddress(0),

--- a/tasks/misc/review-incentive.ts
+++ b/tasks/misc/review-incentive.ts
@@ -188,20 +188,6 @@ task(`review-incentive`, ``)
             exit(1);
         }
 
-        const now = await getBlockTimestamp();
-
-        if (
-          activeInc?.emissionEndTimestamp.gt(BigNumber.from(now)) &&
-          !update
-        ) {
-          console.log(
-            chalk.yellow(
-              `'${network}.${reserve}[${i}]': liquidity mining is active. To update it use --update`
-            )
-          );
-          continue;
-        }
-
         if (!asset || asset == ZERO_ADDRESS) {
           console.log(
             chalk.red(
@@ -211,16 +197,41 @@ task(`review-incentive`, ``)
           exit(1);
         }
 
-        //start or update incentives
-        assetsConf.push({
-          emissionPerSecond: cfg.emissionPerSecond,
-          distributionEnd: now + cfg.duration,
-          asset: asset,
-          reward: cfg.reward,
-          transferStrategy: transferStrat.address,
-          rewardOracle: oracleAddr,
-          totalSupply: "0",
-        });
+        let changed = false;
+        changed = !activeInc?.emissionEndTimestamp.eq(cfg.distributionEnd)
+          ? true
+          : changed;
+        changed = !activeInc?.emissionPerSecond.eq(cfg.emissionPerSecond)
+          ? true
+          : changed;
+        changed =
+          activeInc?.rewardOracleAddress.toLowerCase() !=
+          oracleAddr.toLowerCase()
+            ? true
+            : changed;
+
+        if (changed) {
+          const now = await getBlockTimestamp();
+          if (cfg.distributionEnd <= now) {
+            console.log(
+              chalk.red(
+                `'${network}.${reserve}[${i}]': distribution end must be future date`
+              )
+            );
+            exit(1);
+          }
+
+          //start or update incentives
+          assetsConf.push({
+            emissionPerSecond: cfg.emissionPerSecond,
+            distributionEnd: cfg.distributionEnd,
+            asset: asset,
+            reward: cfg.reward,
+            transferStrategy: transferStrat.address,
+            rewardOracle: oracleAddr,
+            totalSupply: "0",
+          });
+        }
       }
 
       if (assetsConf.length != 0) {

--- a/tasks/misc/review-incentive.ts
+++ b/tasks/misc/review-incentive.ts
@@ -27,18 +27,15 @@ task(`review-incentive`, ``)
     "incentivize",
     "incentivized token address, either atoken or debt token"
   )
-  .addFlag("update")
   .setAction(
     async (
       {
         batch,
         reserve,
-        update,
         incentivize,
       }: {
         batch: boolean;
         reserve: string;
-        update: boolean;
         incentivize: string = "";
       },
       hre


### PR DESCRIPTION
This PR updates `review-incentive` task to accept exact date(unix timestamp) as distribution end + updates all necessary configs.