### PR TITLE
Add apyUSD reserve config, launch proposal, and lark2 network

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -136,6 +136,10 @@ export default {
       eHydrationNetwork.nice,
       222222
     ),
+    [eHydrationNetwork.lark2]: getCommonNetworkConfig(
+      eHydrationNetwork.lark2,
+      222222
+    ),
     [eBaseNetwork.base]: getCommonNetworkConfig(eBaseNetwork.base, 8453),
     [eBaseNetwork.baseGoerli]: getCommonNetworkConfig(
       eBaseNetwork.baseGoerli,

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -105,6 +105,7 @@ export const chainlinkAggregatorProxy: Record<string, string> = {
   [eEthereumNetwork.sepolia]: "0x6c60d915c7a646860dba836ffcb7f112b6cfdc76",
   [eHydrationNetwork.hydration]: "0x8aEAE0bBf623B0E70732086B8D48A6090C311596",
   [eHydrationNetwork.nice]: "0xBd763043861CAF4E7e4E7Ffe951A03dF2Ea7E5AC",
+  [eHydrationNetwork.lark2]: "0x8aEAE0bBf623B0E70732086B8D48A6090C311596",
 };
 
 export const chainlinkEthUsdAggregatorProxy: Record<string, string> = {
@@ -130,6 +131,7 @@ export const chainlinkEthUsdAggregatorProxy: Record<string, string> = {
   [eEthereumNetwork.sepolia]: "0x6c60d915c7a646860dba836ffcb7f112b6cfdc76",
   [eHydrationNetwork.hydration]: "0x8aEAE0bBf623B0E70732086B8D48A6090C311596",
   [eHydrationNetwork.nice]: "0xBd763043861CAF4E7e4E7Ffe951A03dF2Ea7E5AC",
+  [eHydrationNetwork.lark2]: "0x8aEAE0bBf623B0E70732086B8D48A6090C311596",
 };
 
 export const ETHEREUM_SHORT_EXECUTOR =
@@ -156,6 +158,7 @@ export const POOL_ADMIN: Record<string, string> = {
   [eHydrationNetwork.hydration]: "0xaa7e0000000000000000000000000000000aa7e0",
   [eHydrationNetwork.nice]: HYDRATION_TEST_ADMIN,
   [eHydrationNetwork.zombie]: HYDRATION_TEST_ADMIN,
+  [eHydrationNetwork.lark2]: "0xaa7e0000000000000000000000000000000aa7e0",
 };
 
 export const EMERGENCY_ADMIN: Record<string, string> = {
@@ -169,6 +172,7 @@ export const EMERGENCY_ADMIN: Record<string, string> = {
   [eHydrationNetwork.hydration]: "0x146a5e57fa0b8b1e13c53bcf1d05183b1c02b51b", // 7J4KqjeRmGZPVEAogDgtxVenmsJcsvPBCySdDGxaKQ6Yyknj
   [eHydrationNetwork.nice]: "0xb847e0fd2a5e62d621a0382419bddb0a351a6d9c",
   [eHydrationNetwork.zombie]: HYDRATION_TEST_ADMIN,
+  [eHydrationNetwork.lark2]: "0x146a5e57fa0b8b1e13c53bcf1d05183b1c02b51b",
 };
 
 export const DEFAULT_NAMED_ACCOUNTS = {
@@ -218,4 +222,5 @@ export const MULTISIG_ADDRESS: { [key: string]: string } = {
   [eHydrationNetwork.hydration]: "0xaa7e1000000000000000000000000000000aa7e10",
   [eHydrationNetwork.nice]: HYDRATION_TEST_ADMIN,
   [eHydrationNetwork.zombie]: HYDRATION_TEST_ADMIN,
+  [eHydrationNetwork.lark2]: "0xaa7e1000000000000000000000000000000aa7e10",
 };

--- a/helpers/hardhat-config-helpers.ts
+++ b/helpers/hardhat-config-helpers.ts
@@ -102,6 +102,7 @@ export const NETWORKS_RPC_URL: iParamsPerNetwork<string> = {
   [eHydrationNetwork.nice]: "https://rpc.nice.hydration.cloud",
   [eHydrationNetwork.hydration]: process.env.RPC || "https://rpc.hydradx.cloud",
   [eHydrationNetwork.zombie]: process.env.RPC || "http://localhost:9999",
+  [eHydrationNetwork.lark2]: "https://node2.lark.hydration.cloud",
 };
 
 export const LIVE_NETWORKS: iParamsPerNetwork<boolean> = {

--- a/helpers/router-routes.ts
+++ b/helpers/router-routes.ts
@@ -1,0 +1,70 @@
+// @ts-nocheck
+/**
+ * Helper for building `router.forceInsertRoute` extrinsics for newly-launched
+ * assets that follow the standard "paired with HOLLAR in a 2-asset stablepool"
+ * topology (PRIME, EURC, apyUSD, …).
+ *
+ * Without these on-chain routes the router falls back to its default behaviour
+ * (Omnipool only). For new assets that aren't directly in Omnipool, that means
+ * fee-payment swaps, AAVE liquidations, and any client using the router won't
+ * find a path to/from the new asset → they appear "unswappable" until routes
+ * land.
+ *
+ * Standard reference prefixes (HDX → HOLLAR, WETH → HOLLAR) are hardcoded below.
+ * If they change on chain, this file needs an update.
+ */
+
+// Canonical reference assets
+const HDX = 0;
+const WETH = 20;
+const HOLLAR = 222;
+
+// HDX → HOLLAR (single-hop via Omnipool — HOLLAR is in Omnipool directly)
+const HDX_TO_HOLLAR = [{ pool: "Omnipool", assetIn: HDX, assetOut: HOLLAR }];
+
+// WETH → HOLLAR (5 hops via the GETH stablepool and AAVE wraps)
+const WETH_TO_HOLLAR = [
+  { pool: { Stableswap: 104 }, assetIn: WETH, assetOut: 1007 },
+  { pool: { Stableswap: 4200 }, assetIn: 1007, assetOut: 4200 },
+  { pool: "Aave", assetIn: 4200, assetOut: 420 },
+  { pool: "Omnipool", assetIn: 420, assetOut: HOLLAR },
+];
+
+/**
+ * Build the 6 standard `router.forceInsertRoute` calls for an asset paired
+ * with HOLLAR in a 2-asset stablepool.
+ *
+ * @param hydrationTx        polkadot-js `api.tx` for hydradx
+ * @param assetId            id of the underlying asset (e.g. apyUSD = 46)
+ * @param aTokenId           id of the AAVE aToken wrap (e.g. aapyUSD = 1046)
+ * @param sharePoolId        id of the stableswap pool's share asset (e.g. 2-Pool-apyUSD = 146)
+ * @returns                  array of 6 `router.forceInsertRoute` extrinsics
+ *                           (HDX↔asset, HDX↔aToken, HDX↔share, WETH↔asset, WETH↔aToken, WETH↔share)
+ */
+export function buildHollarPairedAssetRoutes(
+  hydrationTx: any,
+  { assetId, aTokenId, sharePoolId }: { assetId: number; aTokenId: number; sharePoolId: number }
+) {
+  const toAsset = [
+    { pool: { Stableswap: sharePoolId }, assetIn: HOLLAR, assetOut: assetId },
+  ];
+  const toAToken = [
+    ...toAsset,
+    { pool: "Aave", assetIn: assetId, assetOut: aTokenId },
+  ];
+  const toShare = [
+    { pool: { Stableswap: sharePoolId }, assetIn: HOLLAR, assetOut: sharePoolId },
+  ];
+
+  const insert = (assetIn: number, assetOut: number, hops: any[]) =>
+    hydrationTx.router.forceInsertRoute({ assetIn, assetOut }, hops);
+
+  return [
+    insert(HDX, assetId, [...HDX_TO_HOLLAR, ...toAsset]),
+    insert(HDX, aTokenId, [...HDX_TO_HOLLAR, ...toAToken]),
+    insert(HDX, sharePoolId, [...HDX_TO_HOLLAR, ...toShare]),
+    insert(WETH, assetId, [...WETH_TO_HOLLAR, ...toAsset]),
+    insert(WETH, aTokenId, [...WETH_TO_HOLLAR, ...toAToken]),
+    insert(WETH, sharePoolId, [...WETH_TO_HOLLAR, ...toShare]),
+  ];
+}

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -80,6 +80,7 @@ export enum eHydrationNetwork {
   hydration = "hydration",
   nice = "nice",
   zombie = "zombie",
+  lark2 = "lark2",
 }
 
 export enum EthereumNetworkNames {

--- a/markets/hydration/index.ts
+++ b/markets/hydration/index.ts
@@ -26,6 +26,7 @@ import {
   strategyPAXG,
   strategyPRIME,
   strategyApyUSD,
+  strategySIGIL,
   strategySOL,
   strategyGSOL,
   strategyEURC,
@@ -77,6 +78,7 @@ export const HydrationConfig: IAaveConfiguration = {
     PAXG: strategyPAXG,
     PRIME: strategyPRIME,
     APYUSD: strategyApyUSD,
+    SIGIL: strategySIGIL,
     SOL: strategySOL,
     "2-POOL-GSOL": strategyGSOL,
     EURC: strategyEURC,
@@ -102,6 +104,7 @@ export const HydrationConfig: IAaveConfiguration = {
       PAXG: tokenAddress(39),
       PRIME: tokenAddress(43),
       APYUSD: tokenAddress(46),
+      SIGIL: tokenAddress(816),
       SOL: tokenAddress(1000752),
       "2-POOL-GSOL": tokenAddress(90001),
       EURC: tokenAddress(44),
@@ -203,6 +206,7 @@ export const HydrationConfig: IAaveConfiguration = {
       PAXG: "0x8fB61B8E81C2f17695F14A136C98b0C4013bc105",
       PRIME: "0xDEe587cC569bf1FcBdcD6d1472031d225f34C307",
       APYUSD: ZERO_ADDRESS, // TODO: fill in after running `hardhat deploy-apyUSDoracle --network hydration`
+      SIGIL: "0xe50AA7afa36A5E04C0b0D0892D0b173c924b662F",
       // GIGASOL oracles
       SOL: "0x2FAA73BCC0115b9F67d2f36E53738B7FF95f0D2C", // DIA SOL/USD oracle
       "2-POOL-GSOL": "0xCD3648A48378cBDa915f6be0A30073b76593Ed9A",

--- a/markets/hydration/index.ts
+++ b/markets/hydration/index.ts
@@ -25,6 +25,7 @@ import {
   strategyHUSDe,
   strategyPAXG,
   strategyPRIME,
+  strategyApyUSD,
   strategySOL,
   strategyGSOL,
   strategyEURC,
@@ -75,6 +76,7 @@ export const HydrationConfig: IAaveConfiguration = {
     "2-POOL-HUSDE": strategyHUSDe,
     PAXG: strategyPAXG,
     PRIME: strategyPRIME,
+    apyUSD: strategyApyUSD,
     SOL: strategySOL,
     "2-POOL-GSOL": strategyGSOL,
     EURC: strategyEURC,
@@ -99,6 +101,7 @@ export const HydrationConfig: IAaveConfiguration = {
       "2-POOL-HUSDE": tokenAddress(113),
       PAXG: tokenAddress(39),
       PRIME: tokenAddress(43),
+      apyUSD: tokenAddress(46),
       SOL: tokenAddress(1000752),
       "2-POOL-GSOL": tokenAddress(90001),
       EURC: tokenAddress(44),
@@ -199,6 +202,7 @@ export const HydrationConfig: IAaveConfiguration = {
       "2-POOL-HUSDE": "0x00000102737461626c657377000000de00000071", // HOLLAR(222) / 2-POOL-HUSDe(113) 10 min. stablesw
       PAXG: "0x8fB61B8E81C2f17695F14A136C98b0C4013bc105",
       PRIME: "0xDEe587cC569bf1FcBdcD6d1472031d225f34C307",
+      apyUSD: ZERO_ADDRESS, // TODO: fill in after running `hardhat deploy-apyUSDoracle --network hydration`
       // GIGASOL oracles
       SOL: "0x2FAA73BCC0115b9F67d2f36E53738B7FF95f0D2C", // DIA SOL/USD oracle
       "2-POOL-GSOL": "0xCD3648A48378cBDa915f6be0A30073b76593Ed9A",

--- a/markets/hydration/index.ts
+++ b/markets/hydration/index.ts
@@ -205,7 +205,7 @@ export const HydrationConfig: IAaveConfiguration = {
       "2-POOL-HUSDE": "0x00000102737461626c657377000000de00000071", // HOLLAR(222) / 2-POOL-HUSDe(113) 10 min. stablesw
       PAXG: "0x8fB61B8E81C2f17695F14A136C98b0C4013bc105",
       PRIME: "0xDEe587cC569bf1FcBdcD6d1472031d225f34C307",
-      APYUSD: ZERO_ADDRESS, // TODO: fill in after running `hardhat deploy-apyUSDoracle --network hydration`
+      APYUSD: "0x286BAaA3F5738ac01EF922B1E913Fcc09916AF96",
       SIGIL: "0xe50AA7afa36A5E04C0b0D0892D0b173c924b662F",
       // GIGASOL oracles
       SOL: "0x2FAA73BCC0115b9F67d2f36E53738B7FF95f0D2C", // DIA SOL/USD oracle

--- a/markets/hydration/index.ts
+++ b/markets/hydration/index.ts
@@ -76,7 +76,7 @@ export const HydrationConfig: IAaveConfiguration = {
     "2-POOL-HUSDE": strategyHUSDe,
     PAXG: strategyPAXG,
     PRIME: strategyPRIME,
-    apyUSD: strategyApyUSD,
+    APYUSD: strategyApyUSD,
     SOL: strategySOL,
     "2-POOL-GSOL": strategyGSOL,
     EURC: strategyEURC,
@@ -101,7 +101,7 @@ export const HydrationConfig: IAaveConfiguration = {
       "2-POOL-HUSDE": tokenAddress(113),
       PAXG: tokenAddress(39),
       PRIME: tokenAddress(43),
-      apyUSD: tokenAddress(46),
+      APYUSD: tokenAddress(46),
       SOL: tokenAddress(1000752),
       "2-POOL-GSOL": tokenAddress(90001),
       EURC: tokenAddress(44),
@@ -202,7 +202,7 @@ export const HydrationConfig: IAaveConfiguration = {
       "2-POOL-HUSDE": "0x00000102737461626c657377000000de00000071", // HOLLAR(222) / 2-POOL-HUSDe(113) 10 min. stablesw
       PAXG: "0x8fB61B8E81C2f17695F14A136C98b0C4013bc105",
       PRIME: "0xDEe587cC569bf1FcBdcD6d1472031d225f34C307",
-      apyUSD: ZERO_ADDRESS, // TODO: fill in after running `hardhat deploy-apyUSDoracle --network hydration`
+      APYUSD: ZERO_ADDRESS, // TODO: fill in after running `hardhat deploy-apyUSDoracle --network hydration`
       // GIGASOL oracles
       SOL: "0x2FAA73BCC0115b9F67d2f36E53738B7FF95f0D2C", // DIA SOL/USD oracle
       "2-POOL-GSOL": "0xCD3648A48378cBDa915f6be0A30073b76593Ed9A",

--- a/markets/hydration/reservesConfigs.ts
+++ b/markets/hydration/reservesConfigs.ts
@@ -247,6 +247,24 @@ export const strategyPRIME: IReserveParams = {
   borrowableIsolation: false,
 };
 
+export const strategySIGIL: IReserveParams = {
+  strategy: rateStrategyStables,
+  baseLTVAsCollateral: "8500",
+  liquidationThreshold: "8800",
+  liquidationBonus: "10700",
+  liquidationProtocolFee: "1000",
+  borrowingEnabled: false,
+  stableBorrowRateEnabled: false,
+  flashLoanEnabled: false,
+  reserveDecimals: "18",
+  aTokenImpl: eContractid.AToken,
+  reserveFactor,
+  supplyCap: "1100000",
+  borrowCap: "0",
+  debtCeiling,
+  borrowableIsolation: false,
+};
+
 export const strategyApyUSD: IReserveParams = {
   strategy: rateStrategyVolatileOne,
   baseLTVAsCollateral: "8500",

--- a/markets/hydration/reservesConfigs.ts
+++ b/markets/hydration/reservesConfigs.ts
@@ -247,6 +247,24 @@ export const strategyPRIME: IReserveParams = {
   borrowableIsolation: false,
 };
 
+export const strategyApyUSD: IReserveParams = {
+  strategy: rateStrategyVolatileOne,
+  baseLTVAsCollateral: "8500",
+  liquidationThreshold: "8800",
+  liquidationBonus: "10700",
+  liquidationProtocolFee: "1000",
+  borrowingEnabled: true,
+  stableBorrowRateEnabled: false,
+  flashLoanEnabled: false,
+  reserveDecimals: "18",
+  aTokenImpl: eContractid.AToken,
+  reserveFactor,
+  supplyCap: "5000000",
+  borrowCap: "3000000",
+  debtCeiling: "222222200",
+  borrowableIsolation: false,
+};
+
 // GIGASOL reserve configurations
 export const strategySOL: IReserveParams = {
   strategy: rateStrategyDOT,

--- a/tasks/misc/deploy-apyUSDoracle.ts
+++ b/tasks/misc/deploy-apyUSDoracle.ts
@@ -1,0 +1,21 @@
+import { task } from "hardhat/config";
+import { POOL_ADMIN } from "./../../helpers/constants";
+
+task(`deploy-apyUSDoracle`, `Deploys the apyUSD oracle contract`).setAction(
+  async (_, hre) => {
+    if (!hre.network.config.chainId) {
+      throw new Error("INVALID_CHAIN_ID");
+    }
+    const network = hre.network.name;
+    const admin = POOL_ADMIN[network];
+
+    const { deployer } = await hre.getNamedAccounts();
+    const artifact = await hre.deployments.deploy(`apyUSDoracle`, {
+      from: deployer,
+      contract: "ManagedOracle",
+      args: ["apyUSD/USD", 1, admin, 136723180],
+    });
+
+    console.log("apyUSD oracle deployed at:", artifact.address);
+  }
+);

--- a/tasks/proposals/apyusd-liquidity.ts
+++ b/tasks/proposals/apyusd-liquidity.ts
@@ -1,0 +1,114 @@
+// @ts-nocheck
+import {
+  getApi,
+  generateProposalV2,
+  dispatchAs,
+} from "../../helpers/hydration-proposal.js";
+import { task } from "hardhat/config";
+import ProposalDecoder from "../../helpers/proposal-decoder";
+
+// Re-seed the 2-Pool-apyUSD (146) stableswap.
+//
+// The original launch (block 12561497) created the pool and borrowed 500k
+// HOLLAR to the treasury, but its `addAssetsLiquidity` reverted with
+// stableswap.InsufficientBalance: the apyUSD seed was hardcoded to a rounded-up
+// 363,156 while the treasury only held 363,155.677…, ~0.32 apyUSD short.
+// `utility.dispatchAs` swallows the inner error, so the batch reported success
+// and the pool was left EMPTY (LP issuance 0). The 500k HOLLAR is still idle in
+// the treasury, so no new borrow is needed here.
+//
+// Front-running guard: while the pool is empty, anyone can be the first LP. A
+// third party seeding it first (especially imbalanced, against the MMOracle peg)
+// could make our fixed-amount add fail or land at a bad ratio. So this task
+// emits TWO artifacts:
+//
+//   1. FREEZE call  — set both pool assets to Tradability{bits:0} (FROZEN).
+//      Submit this NOW via the Technical Committee so nobody can add liquidity
+//      while the referendum runs.
+//
+//   2. PROPOSAL     — (whitelisted) un-freeze both assets back to {bits:15}
+//      (the default, all-enabled), THEN add the treasury's liquidity, all in one
+//      atomic batch. After it runs the pool is seeded and normally tradable.
+//
+// Tradability bitflags (pallet_stableswap::types::Tradability):
+//   SELL=1  BUY=2  ADD_LIQUIDITY=4  REMOVE_LIQUIDITY=8  →  all-on = 15, FROZEN = 0
+const FROZEN = { bits: 0 };
+const ENABLED = { bits: 15 };
+
+task(
+  `apyusd-liquidity`,
+  `Freeze + seed the 2-Pool-apyUSD (146) stableswap with treasury HOLLAR + apyUSD`
+).setAction(async function (_, hre) {
+  const hydrationTx = (await getApi()).tx;
+
+  const HOLLAR = 222;
+  const APYUSD = 46;
+  const poolAPYUSD = 146;
+  const treasury = "7L53bUTBopuwFt3mKUfmkzgGLayYa1Yvn1hAg9v5UMrQzTfh";
+
+  // Treasury already holds both seeds (verified on chain at head 12562526):
+  //   HOLLAR  552,147.525  >= 500,000
+  //   apyUSD  363,155.677  >= 363,155
+  const hollarSeed = "500000000000000000000000"; // 500,000
+  const apyUSDSeed = "363155000000000000000000"; // 363,155 (rounded down)
+
+  const decoder = new ProposalDecoder(hre);
+  await decoder.init();
+
+  // ---- Artifact 2: whitelisted proposal — unfreeze, then seed ----
+  const calls = [
+    hydrationTx.stableswap.setAssetTradableState(poolAPYUSD, APYUSD, ENABLED),
+    hydrationTx.stableswap.setAssetTradableState(poolAPYUSD, HOLLAR, ENABLED),
+    await dispatchAs(
+      treasury,
+      hydrationTx.stableswap.addAssetsLiquidity(
+        ...Object.values({
+          poolId: poolAPYUSD,
+          assets: [
+            { assetId: HOLLAR, amount: hollarSeed },
+            { assetId: APYUSD, amount: apyUSDSeed },
+          ],
+          minShares: 0,
+        })
+      )
+    ),
+  ];
+
+  const preimage = await generateProposalV2(calls, false);
+  console.log("\n=== 2) PROPOSAL (unfreeze + seed) ===");
+  console.log("preimage:");
+  console.log(preimage.toHex());
+  decoder.printTree(decoder.transformCall(preimage.toHuman()));
+  console.log("preimage hash (this is what the TC motion whitelists):");
+  console.log(preimage.hash.toHex());
+
+  const { proposal } = await generateProposalV2(calls, true);
+  console.log("\nwhitelisted proposal (submit on Whitelisted Caller track):");
+  console.log(proposal.toHex());
+  decoder.printTree(decoder.transformCall(proposal.toHuman()));
+  console.log("proposal hash:");
+  console.log(proposal.hash.toHex());
+
+  // ---- Artifact 1: single Technical Committee motion ----
+  // Verified on a tarn fork @ #12562526: a TC MAJORITY (>=4/7) satisfies the
+  // authority origin for both setAssetTradableState and whitelist.whitelistCall
+  // (3/7 -> BadOrigin, 4/7 -> Ok). One motion does both: freeze the pool now AND
+  // whitelist the seed proposal above so it can run on the Whitelisted Caller
+  // track. batchAll => atomic; whitelisted hash = the preimage hash above.
+  const TC_THRESHOLD = 4; // majority of 7
+  const tcBatch = hydrationTx.utility.batchAll([
+    hydrationTx.stableswap.setAssetTradableState(poolAPYUSD, APYUSD, FROZEN),
+    hydrationTx.stableswap.setAssetTradableState(poolAPYUSD, HOLLAR, FROZEN),
+    hydrationTx.whitelist.whitelistCall(preimage.hash),
+  ]).method;
+  const tcPropose = hydrationTx.technicalCommittee.propose(
+    TC_THRESHOLD,
+    tcBatch,
+    (tcBatch.toHex().length - 2) / 2
+  ).method;
+  console.log("\n=== 1) TC MOTION: freeze + whitelist (submit NOW, threshold 4/7) ===");
+  console.log(tcPropose.toHex());
+  decoder.printTree(decoder.transformCall(tcPropose.toHuman()));
+  console.log("inner batch hash:");
+  console.log(tcBatch.hash.toHex());
+});

--- a/tasks/proposals/apyusd.ts
+++ b/tasks/proposals/apyusd.ts
@@ -1,0 +1,154 @@
+// @ts-nocheck
+import {
+  ConfigNames,
+  getOracleByAsset,
+  loadPoolConfig,
+} from "../../helpers/market-config-helpers";
+import {
+  getApi,
+  location,
+  generateProposalV2,
+  dispatchAs,
+  aaveManagerCall,
+} from "../../helpers/hydration-proposal.js";
+import { MARKET_NAME } from "../../helpers/env";
+import { task } from "hardhat/config";
+import {
+  getBatch,
+  clearBatch,
+} from "../../helpers/transaction-batch";
+import {
+  FORK,
+  getPoolAddressesProvider,
+  POOL_ADMIN,
+} from "../../helpers";
+import ProposalDecoder from "../../helpers/proposal-decoder";
+
+task(`apyusd`, ``).setAction(async function (_, hre) {
+  const { utils } = hre.ethers;
+  const networkId = FORK ? FORK : hre.network.name;
+  const admin = POOL_ADMIN[networkId];
+  const cfg = await loadPoolConfig(MARKET_NAME as ConfigNames);
+  const poolAddressesProvider = await getPoolAddressesProvider();
+  const hydrationTx = (await getApi()).tx;
+
+  await hre.run("init-reserve", {
+    symbol: "apyUSD",
+    batch: true,
+  });
+
+  await hre.run("review-reserve-factors", {
+    fix: true,
+    batch: true,
+  });
+
+  await hre.run("review-debt-ceiling", {
+    fix: true,
+    batch: true,
+  });
+
+  const oracle = await getOracleByAsset(cfg, "apyUSD");
+  const price = 1.3672318;
+
+  await hre.run("set-oracle-price", {
+    oracle,
+    price: Math.round(price * 10 ** 8).toString(),
+  });
+
+  const txs = await Promise.all(
+    getBatch().map((tx) => aaveManagerCall({ ...tx, from: admin }))
+  );
+  clearBatch();
+
+  const deployer = await poolAddressesProvider.getPoolConfigurator();
+  const nonce = await hre.ethers.provider.getTransactionCount(deployer);
+  const aToken = utils.getContractAddress({
+    from: deployer,
+    nonce: nonce,
+  });
+
+  const HOLLAR = 222;
+  const APYUSD = 46;
+  const aAPYUSD = 1046;
+  const poolAPYUSD = 146;
+  const treasury = "7L53bUTBopuwFt3mKUfmkzgGLayYa1Yvn1hAg9v5UMrQzTfh";
+
+  // 363,156 apyUSD (held on 16RJh4z1…j4RE multisig, pending transfer to treasury) + 500,000 HOLLAR borrowed by treasury
+  const apyUSDSeed = "363156000000000000000000";
+
+  const rootTxs = [
+    hydrationTx.assetRegistry.register(
+      ...Object.values({
+        id: aAPYUSD,
+        name: "aapyUSD",
+        assetType: "Erc20",
+        existentialDeposit: "14705882352941200",
+        symbol: "aapyUSD",
+        decimals: 18,
+        location: location(aToken),
+        xcmRateLimit: null,
+        isSufficient: true,
+      })
+    ),
+    hydrationTx.multiTransactionPayment.addCurrency(
+      ...Object.values({
+        asset: aAPYUSD,
+        price: "3264705882352940000000",
+      })
+    ),
+    hydrationTx.assetRegistry.register(
+      ...Object.values({
+        id: poolAPYUSD,
+        name: "2-Pool-apyUSD",
+        assetType: "StableSwap",
+        existentialDeposit: "33000000000000000",
+        symbol: "2-Pool-apyUSD",
+        decimals: 18,
+        location: null,
+        xcmRateLimit: null,
+        isSufficient: true,
+      })
+    ),
+    hydrationTx.multiTransactionPayment.addCurrency(
+      ...Object.values({
+        asset: poolAPYUSD,
+        price: "11190000000000000000000",
+      })
+    ),
+    hydrationTx.stableswap.createPoolWithPegs(
+      ...Object.values({
+        shareAsset: poolAPYUSD,
+        assets: [APYUSD, HOLLAR],
+        amplification: 100,
+        fee: 400,
+        pegSource: [{ MMOracle: oracle }, { value: [1, 1] }],
+        maxPegUpdate: 120,
+      })
+    ),
+    await dispatchAs(
+      treasury,
+      hydrationTx.stableswap.addAssetsLiquidity(
+        ...Object.values({
+          poolId: poolAPYUSD,
+          assets: [
+            { assetId: HOLLAR, amount: "500000000000000000000000" },
+            { assetId: APYUSD, amount: apyUSDSeed },
+          ],
+          minShares: 0,
+        })
+      )
+    ),
+  ];
+
+  const { whitelistedCall, proposal } = await generateProposalV2(
+    [...txs, ...rootTxs],
+    true
+  );
+  const decoder = new ProposalDecoder(hre);
+  await decoder.init();
+  console.log("whitelisted call hash:");
+  console.log(whitelistedCall.hash.toString());
+  console.log("proposal preimage:");
+  console.log(proposal.toHex());
+  decoder.printTree(decoder.transformCall(whitelistedCall.toHuman()));
+});

--- a/tasks/proposals/apyusd.ts
+++ b/tasks/proposals/apyusd.ts
@@ -13,6 +13,7 @@ import {
   rootEvmCall,
 } from "../../helpers/hydration-proposal.js";
 import { getPool } from "../../helpers/contract-getters";
+import { buildHollarPairedAssetRoutes } from "../../helpers/router-routes";
 import { MARKET_NAME } from "../../helpers/env";
 import { task } from "hardhat/config";
 import {
@@ -89,7 +90,7 @@ task(`apyusd`, ``).setAction(async function (_, hre) {
     2, // interestRateMode: variable
     0, // referralCode
     treasuryEvm,
-    { gasLimit: 1_000_000 }
+    { gasLimit: 3_000_000 } // 1M reverts out-of-gas on lark2; 3M leaves headroom
   );
   borrowTx.from = treasuryEvm;
   const treasuryBorrow = await rootEvmCall(borrowTx);
@@ -157,6 +158,11 @@ task(`apyusd`, ``).setAction(async function (_, hre) {
         })
       )
     ),
+    ...buildHollarPairedAssetRoutes(hydrationTx, {
+      assetId: APYUSD,
+      aTokenId: aAPYUSD,
+      sharePoolId: poolAPYUSD,
+    }),
   ];
 
   const proposal = await generateProposalV2([...txs, ...rootTxs], false);

--- a/tasks/proposals/apyusd.ts
+++ b/tasks/proposals/apyusd.ts
@@ -10,7 +10,9 @@ import {
   generateProposalV2,
   dispatchAs,
   aaveManagerCall,
+  rootEvmCall,
 } from "../../helpers/hydration-proposal.js";
+import { getPool } from "../../helpers/contract-getters";
 import { MARKET_NAME } from "../../helpers/env";
 import { task } from "hardhat/config";
 import {
@@ -33,7 +35,7 @@ task(`apyusd`, ``).setAction(async function (_, hre) {
   const hydrationTx = (await getApi()).tx;
 
   await hre.run("init-reserve", {
-    symbol: "apyUSD",
+    symbol: "APYUSD",
     batch: true,
   });
 
@@ -47,7 +49,7 @@ task(`apyusd`, ``).setAction(async function (_, hre) {
     batch: true,
   });
 
-  const oracle = await getOracleByAsset(cfg, "apyUSD");
+  const oracle = await getOracleByAsset(cfg, "APYUSD");
   const price = 1.3672318;
 
   await hre.run("set-oracle-price", {
@@ -72,9 +74,25 @@ task(`apyusd`, ``).setAction(async function (_, hre) {
   const aAPYUSD = 1046;
   const poolAPYUSD = 146;
   const treasury = "7L53bUTBopuwFt3mKUfmkzgGLayYa1Yvn1hAg9v5UMrQzTfh";
+  const treasuryEvm = "0x6d6f646c70792f74727372790000000000000000";
+  const HOLLAR_EVM = "0x531a654d1696ed52e7275a8cede955e82620f99a";
 
-  // 363,156 apyUSD (held on 16RJh4z1…j4RE multisig, pending transfer to treasury) + 500,000 HOLLAR borrowed by treasury
+  // 363,156 apyUSD (held on 16RJh4z1…j4RE multisig, pending transfer to treasury) + 500,000 HOLLAR borrowed by treasury from AAVE
   const apyUSDSeed = "363156000000000000000000";
+  const hollarSeed = "500000000000000000000000";
+
+  // Treasury borrows 500,000 HOLLAR (variable rate) from AAVE against existing collateral
+  const pool = await getPool();
+  const borrowTx = await pool.populateTransaction.borrow(
+    HOLLAR_EVM,
+    hollarSeed,
+    2, // interestRateMode: variable
+    0, // referralCode
+    treasuryEvm,
+    { gasLimit: 1_000_000 }
+  );
+  borrowTx.from = treasuryEvm;
+  const treasuryBorrow = await rootEvmCall(borrowTx);
 
   const rootTxs = [
     hydrationTx.assetRegistry.register(
@@ -125,13 +143,14 @@ task(`apyusd`, ``).setAction(async function (_, hre) {
         maxPegUpdate: 120,
       })
     ),
+    treasuryBorrow,
     await dispatchAs(
       treasury,
       hydrationTx.stableswap.addAssetsLiquidity(
         ...Object.values({
           poolId: poolAPYUSD,
           assets: [
-            { assetId: HOLLAR, amount: "500000000000000000000000" },
+            { assetId: HOLLAR, amount: hollarSeed },
             { assetId: APYUSD, amount: apyUSDSeed },
           ],
           minShares: 0,
@@ -140,15 +159,12 @@ task(`apyusd`, ``).setAction(async function (_, hre) {
     ),
   ];
 
-  const { whitelistedCall, proposal } = await generateProposalV2(
-    [...txs, ...rootTxs],
-    true
-  );
+  const proposal = await generateProposalV2([...txs, ...rootTxs], false);
   const decoder = new ProposalDecoder(hre);
   await decoder.init();
-  console.log("whitelisted call hash:");
-  console.log(whitelistedCall.hash.toString());
   console.log("proposal preimage:");
   console.log(proposal.toHex());
-  decoder.printTree(decoder.transformCall(whitelistedCall.toHuman()));
+  decoder.printTree(decoder.transformCall(proposal.toHuman()));
+  console.log("hash:");
+  console.log(proposal.hash.toHex());
 });

--- a/tasks/proposals/sigil-launch.ts
+++ b/tasks/proposals/sigil-launch.ts
@@ -1,0 +1,123 @@
+// @ts-nocheck
+import {
+  ConfigNames,
+  loadPoolConfig,
+} from "../../helpers/market-config-helpers";
+import {
+  generateProposalV2,
+  getApi,
+  location,
+  aaveManagerCall,
+  dispatchAs,
+} from "../../helpers/hydration-proposal.js";
+import { MARKET_NAME } from "../../helpers/env";
+import { task } from "hardhat/config";
+import {
+  getBatch,
+  clearBatch,
+} from "../../helpers/transaction-batch";
+import {
+  FORK,
+  getPoolAddressesProvider,
+  POOL_ADMIN,
+} from "../../helpers";
+import ProposalDecoder from "../../helpers/proposal-decoder";
+
+task(`sigil-launch`, ``).setAction(async function (_, hre) {
+  const { utils } = hre.ethers;
+  const networkId = FORK ? FORK : hre.network.name;
+  const admin = POOL_ADMIN[networkId];
+  const cfg = await loadPoolConfig(MARKET_NAME as ConfigNames);
+  const poolAddressesProvider = await getPoolAddressesProvider();
+  const hydrationTx = (await getApi()).tx;
+
+  console.log("init SIGIL reserve");
+  await hre.run("init-reserve", {
+    symbol: "SIGIL",
+    batch: true,
+  });
+
+  const txs = await Promise.all(
+    getBatch().map((tx) => aaveManagerCall({ ...tx, from: admin }))
+  );
+  clearBatch();
+
+  // predict aToken address from deployer nonce
+  const deployer = await poolAddressesProvider.getPoolConfigurator();
+  const nonce = await hre.ethers.provider.getTransactionCount(deployer);
+  const aToken = utils.getContractAddress({
+    from: deployer,
+    nonce: nonce,
+  });
+  console.log("predicted aToken address:", aToken);
+
+  const SIGIL = 816;
+  const aSIGIL = 1816;
+  const treasury = "7L53bUTBopuwFt3mKUfmkzgGLayYa1Yvn1hAg9v5UMrQzTfh";
+
+  // asset must exist before EVM calls can reference tokenAddress(816)
+  const preRegistrationTxs = [
+    // register SIGIL token in Hydration asset registry
+    hydrationTx.assetRegistry.register(
+      ...Object.values({
+        id: SIGIL,
+        name: "Sigil Stable",
+        assetType: "Token",
+        existentialDeposit: "20000000000000000",
+        symbol: "SIGIL",
+        decimals: 18,
+        location: null,
+        xcmRateLimit: null,
+        isSufficient: true,
+      })
+    ),
+    // mint initial Treasury balance (1.1M SIGIL)
+    hydrationTx.currencies.updateBalance(
+      treasury,
+      SIGIL,
+      "1100000000000000000000000"
+    ),
+  ];
+
+  // aToken registration must come after initReserves deploys it
+  const postRegistrationTxs = [
+    hydrationTx.assetRegistry.register(
+      ...Object.values({
+        id: aSIGIL,
+        name: "aSIGIL",
+        assetType: "Erc20",
+        existentialDeposit: "20000000000000000",
+        symbol: "aSIGIL",
+        decimals: 18,
+        location: location(aToken),
+        xcmRateLimit: null,
+        isSufficient: true,
+      })
+    ),
+    // Treasury swaps entire 1.1M SIGIL for aSIGIL via Aave AMM router
+    await dispatchAs(
+      treasury,
+      hydrationTx.router.sell(
+        ...Object.values({
+          assetIn: SIGIL,
+          assetOut: aSIGIL,
+          amount: "1100000000000000000000000",
+          minAmountOut: 0,
+          route: [{ pool: "Aave", assetIn: SIGIL, assetOut: aSIGIL }],
+        })
+      )
+    ),
+  ];
+
+  console.log("generating proposal preimage...");
+  const preimage = await generateProposalV2(
+    [...preRegistrationTxs, ...txs, ...postRegistrationTxs],
+    false
+  );
+
+  const decoder = new ProposalDecoder(hre);
+  await decoder.init();
+  console.log("proposal preimage:");
+  console.log(preimage.toHex());
+  decoder.printTree(decoder.transformCall(preimage.toHuman()));
+});


### PR DESCRIPTION
- strategyApyUSD: same risk params as PRIME launch (LTV 8500 / LT 8800 / LB 10700 / liqProtocolFee 1000, volatile rate strategy) but 18 decimals, supplyCap 5M, borrowCap 3M, debtCeiling $2.22M
- markets/hydration/index.ts: apyUSD entry in ReservesConfig, ReserveAssets (tokenAddress 46), and ChainlinkAggregator (filled in after deploy)
- deploy-apyUSDoracle: ManagedOracle("apyUSD/USD", 1, admin, 136723180)
- apyusd proposal: mirrors prime.ts pattern - registers aapyUSD (1046) and 2-Pool-apyUSD (146), creates stableswap pool paired with HOLLAR (amp 100, fee 400, MMOracle peg, maxPegUpdate 120), treasury-seeds 500k HOLLAR + 363,156 apyUSD
- lark2 network alias added to enable testing the oracle deploy on the node2 lark fork; mirrors mainnet admin/multisig addresses since lark2 forks mainnet