### PR TITLE
Add rateStrategyPRIME (0-2-20 @ 75%) and switch PRIME to it

### DIFF
--- a/markets/hydration/rateStrategies.ts
+++ b/markets/hydration/rateStrategies.ts
@@ -53,6 +53,19 @@ export const rateStrategyDOT5: IInterestRateStrategyParams = {
   optimalStableToTotalDebtRatio: parseUnits("0.2", 27).toString(),
 };
 
+export const rateStrategyPRIME: IInterestRateStrategyParams = {
+  name: "rateStrategyPRIME",
+  optimalUsageRatio: parseUnits("0.75", 27).toString(),
+  baseVariableBorrowRate: "0",
+  variableRateSlope1: parseUnits("0.02", 27).toString(),
+  variableRateSlope2: parseUnits("0.2", 27).toString(),
+  stableRateSlope1: parseUnits("0.07", 27).toString(),
+  stableRateSlope2: parseUnits("3", 27).toString(),
+  baseStableRateOffset: parseUnits("0.02", 27).toString(),
+  stableRateExcessOffset: parseUnits("0.05", 27).toString(),
+  optimalStableToTotalDebtRatio: parseUnits("0.2", 27).toString(),
+};
+
 export const rateStrategyStables: IInterestRateStrategyParams = {
   name: "rateStrategyStables",
   optimalUsageRatio: parseUnits("0.7", 27).toString(),

--- a/markets/hydration/reservesConfigs.ts
+++ b/markets/hydration/reservesConfigs.ts
@@ -3,6 +3,7 @@ import { eContractid, IReserveParams } from "../../helpers/types";
 import {
   rateStrategyDOT,
   rateStrategyDOT5,
+  rateStrategyPRIME,
   rateStrategyStables,
   rateStrategyStables80,
 } from "./rateStrategies";
@@ -230,7 +231,7 @@ export const strategyPAXG: IReserveParams = {
 };
 
 export const strategyPRIME: IReserveParams = {
-  strategy: rateStrategyVolatileOne,
+  strategy: rateStrategyPRIME,
   baseLTVAsCollateral: "8500",
   liquidationThreshold: "8800",
   liquidationBonus: "10700",

--- a/tasks/proposals/prime-rate-strategy.ts
+++ b/tasks/proposals/prime-rate-strategy.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+import {
+  aaveManagerCall,
+  getApi,
+  generateProposalV2,
+} from "../../helpers/hydration-proposal.js";
+import { task } from "hardhat/config";
+import { getBatch } from "../../helpers/transaction-batch";
+import {
+  FORK,
+  getACLManager,
+  getPoolAddressesProvider,
+  POOL_ADMIN,
+} from "../../helpers";
+import ProposalDecoder from "../../helpers/proposal-decoder";
+
+// Switches the PRIME reserve to the rateStrategyPRIME interest rate strategy
+// (0% base, 2% slope1, 20% slope2, 75% optimal usage). Deploys a fresh
+// DefaultReserveInterestRateStrategy contract and emits the governance
+// proposal that points PRIME at it.
+task(`prime-rate-strategy`, ``).setAction(async function (_, hre) {
+  const { poolAdmin } = await hre.getNamedAccounts();
+  const signer = await hre.ethers.getSigner(poolAdmin);
+  const poolAddressesProvider = await getPoolAddressesProvider();
+  const aclManager = (
+    await getACLManager(await poolAddressesProvider.getACLManager())
+  ).connect(signer);
+  console.log("poolAdmin", poolAdmin);
+  const networkId = FORK ? FORK : hre.network.name;
+  const admin = POOL_ADMIN[networkId];
+  const isPoolAdmin = await aclManager.isPoolAdmin(admin);
+  if (!isPoolAdmin) {
+    console.error("not pool admin " + admin);
+    return;
+  }
+
+  await hre.run("review-rate-strategies", {
+    deploy: true,
+    fix: true,
+    batch: true,
+    only: "PRIME",
+  });
+
+  const txs = await Promise.all(
+    getBatch().map((tx) => aaveManagerCall({ ...tx, from: admin }))
+  );
+
+  const proposal = await generateProposalV2(txs, false);
+
+  console.log("proposal hash:", proposal.hash.toHex());
+  console.log("proposal batch preimage:");
+  console.log(proposal.toHex());
+
+  const decoder = new ProposalDecoder(hre);
+  await decoder.init();
+  decoder.printTree(decoder.transformCall(proposal.toHuman()));
+});


### PR DESCRIPTION
New interest rate strategy for PRIME: 0% base, 2% slope1, 20% slope2, 75% optimal usage. Repoints strategyPRIME from rateStrategyVolatileOne to rateStrategyPRIME, and adds the prime-rate-strategy proposal task (scoped to --only PRIME) that deploys the strategy contract and emits the governance preimage switching PRIME to it.