### PR TITLE
fix(bil-vault): H-01 checkpoint via monotonic index (slim alt to #47)

### DIFF
--- a/bil-vault/keeper/src/keeper.ts
+++ b/bil-vault/keeper/src/keeper.ts
@@ -85,6 +85,13 @@ const VAULT_ABI = [
     outputs: [{ name: '', type: 'uint256' }],
   },
   {
+    name: 'syncMaturities',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [{ name: 'maxPositions', type: 'uint256' }],
+    outputs: [{ name: 'processed', type: 'uint256' }],
+  },
+  {
     name: 'pokeDecentral',
     type: 'function',
     stateMutability: 'nonpayable',
@@ -183,6 +190,10 @@ export class BILKeeper {
     const now = Math.floor(Date.now() / 1000);
     console.log(`\n[${new Date().toISOString()}] Running keeper cycle...`);
 
+    // Keep maturity accounting current even while the vault is paused, when
+    // pokeDecentral and pokeQueue are intentionally unavailable.
+    await this.syncMaturitiesIfDue();
+
     // 1. Read vault state
     const [positionCount, positionHead, idleHollar, totalQueuedBil, minReinvestAmount] =
       await Promise.all([
@@ -237,6 +248,25 @@ export class BILKeeper {
     await this.autoClaimSettled();
 
     console.log('  Cycle complete.');
+  }
+
+  private async syncMaturitiesIfDue(): Promise<void> {
+    const batch = 50n;
+    try {
+      const { result } = await this.publicClient.simulateContract({
+        account: this.account,
+        address: this.vaultAddress,
+        abi: VAULT_ABI,
+        functionName: 'syncMaturities',
+        args: [batch],
+      });
+      if ((result as bigint) === 0n) return;
+
+      console.log(`  Synchronizing up to ${batch} matured positions...`);
+      await this.writeContract('syncMaturities', [batch]);
+    } catch (err) {
+      console.error('  syncMaturities() failed:', err);
+    }
   }
 
   // ─── Auto-claim for opted-in controllers ─────────────────────────────

--- a/bil-vault/src/BILVault.sol
+++ b/bil-vault/src/BILVault.sol
@@ -60,6 +60,11 @@ contract BILVault is
     ///      cadence keeps head in sync without requiring a fresh redemption.
     uint256 internal constant MAX_POSITION_HEAD_SWEEP = 50;
 
+    /// @dev Maximum due maturities folded into a queue or lifecycle call.
+    ///      Deposits remain disabled until permissionless synchronization has
+    ///      drained every overdue root.
+    uint256 internal constant MAX_MATURITY_SYNC = 50;
+
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
     /// @notice Fast-path role for the Hydration technical committee.
@@ -80,32 +85,6 @@ contract BILVault is
     // ═══════════════════════════════════════════════════════════════════════
     //                          STRUCTS & ENUMS
     // ═══════════════════════════════════════════════════════════════════════
-
-    enum NFTState {
-        Active,
-        YieldWithdrawalRequested,
-        YieldClaimed,
-        PrincipalWithdrawalRequested,
-        Redeemed
-    }
-
-    struct NFTPosition {
-        uint256 tokenId;
-        uint256 principal;
-        uint256 apyWad;
-        uint256 depositTime;
-        uint256 maturityTime;
-        uint256 yieldStartTime;
-        NFTState state;
-        // Yield amount Decentral has locked in for this position after the
-        // requestYieldWithdrawal call but before executeYieldWithdrawal. While
-        // the position is in YieldWithdrawalRequested, this is the deterministic
-        // amount that will land in idleHollar at execute. The bucket is no
-        // longer accruing yield for this position from request-time onward, so
-        // pendingYield (plus totalPendingYield in totalAssets) keeps the
-        // accounting flat across the admin-approval delay.
-        uint256 pendingYield;
-    }
 
     // RedemptionRequest struct moved to QueueLib.Request — see libraries/QueueLib.sol
 
@@ -185,7 +164,7 @@ contract BILVault is
     // ═══════════════════════════════════════════════════════════════════════
 
     /// @notice All NFT positions, ordered by deposit time
-    NFTPosition[] public positions;
+    QueueLib.NFTPosition[] public positions;
     /// @notice Index of the first non-redeemed position
     uint256 public positionHead;
 
@@ -309,6 +288,11 @@ contract BILVault is
     event PoolRegistered(address indexed pool);
     event ActiveDepositPoolSet(address indexed pool);
     event PoolRetired(address indexed pool);
+    event PositionYieldCapped(
+        uint256 indexed positionIndex,
+        uint256 maturityTime,
+        uint256 pendingYield
+    );
 
     // ═══════════════════════════════════════════════════════════════════════
     //                            ERRORS
@@ -366,6 +350,7 @@ contract BILVault is
         uint256 shortfallBps
     );
     error BpsAboveMax();
+    error MaturityBacklog();
 
     // ═══════════════════════════════════════════════════════════════════════
     //                         INITIALIZER
@@ -427,7 +412,15 @@ contract BILVault is
     function totalAssets() public view returns (uint256) {
         uint256 accruedYield = 0;
         if (yieldRateSum > 0) {
-            uint256 gross = block.timestamp * yieldRateSum;
+            // An overdue heap root clamps the entire live aggregate. Later
+            // positions may be conservatively under-counted until sync, but
+            // phantom post-maturity yield is impossible even without a keeper.
+            uint256 accrualTime = block.timestamp;
+            if (_maturityHeap.length > 0) {
+                uint256 earliest = _maturityHeap[0] >> 128;
+                if (earliest < accrualTime) accrualTime = earliest;
+            }
+            uint256 gross = accrualTime * yieldRateSum;
             if (gross > yieldOffsetSum) {
                 accruedYield =
                     (gross - yieldOffsetSum) /
@@ -465,6 +458,7 @@ contract BILVault is
     ) external nonReentrant whenNotPaused returns (uint256 shares) {
         if (receiver == address(0)) revert ZeroAddress();
         shares = _validateAndPreviewShares(assets);
+        _requireNoMaturityBacklog();
         _deposit(msg.sender, receiver, assets, shares);
     }
 
@@ -479,6 +473,7 @@ contract BILVault is
     ) external nonReentrant whenNotPaused returns (uint256 assets) {
         if (receiver == address(0)) revert ZeroAddress();
         if (shares == 0) revert ZeroAmount();
+        _requireNoMaturityBacklog();
         assets = previewMint(shares);
         // Reuse the same validation path: paused/zero/cap checks
         // run again on the computed asset amount.
@@ -513,20 +508,21 @@ contract BILVault is
 
         uint256 idx = positions.length;
         positions.push(
-            NFTPosition({
+            QueueLib.NFTPosition({
                 tokenId: tokenId,
                 principal: amount,
                 apyWad: apyWad,
                 depositTime: block.timestamp,
                 maturityTime: block.timestamp + _investmentPeriod(pool),
                 yieldStartTime: block.timestamp,
-                state: NFTState.Active,
+                state: QueueLib.NFTState.Active,
+                yieldCapped: false,
                 pendingYield: 0
             })
         );
         positionPool[idx] = pool;
 
-        _addToBucket(apyWad, amount, block.timestamp);
+        _addToBucket(idx, apyWad, amount, block.timestamp);
     }
 
     /// @notice ERC-7540 async-redemption request. Escrows `shares` hDCL
@@ -623,20 +619,12 @@ contract BILVault is
             // Head sweep — same logic as before, bounded by MAX_QUEUE_ITERATIONS
             // so the canceller's gas stays bounded even with many head holes.
             if (requestId == queueHead) {
-                uint256 head = queueHead;
-                uint256 tail = queueTail;
-                uint256 swept;
-                while (
-                    head < tail &&
-                    swept < MAX_QUEUE_ITERATIONS &&
-                    redemptionQueue[head].user == address(0)
-                ) {
-                    unchecked {
-                        head++;
-                        swept++;
-                    }
-                }
-                queueHead = head;
+                queueHead = QueueLib.advanceQueueHead(
+                    redemptionQueue,
+                    queueHead,
+                    queueTail,
+                    MAX_QUEUE_ITERATIONS
+                );
             }
         }
     }
@@ -730,56 +718,54 @@ contract BILVault is
     function pokeDecentral(
         uint256 positionIndex
     ) external nonReentrant whenNotPaused {
-        NFTPosition storage pos = positions[positionIndex];
-        if (pos.state == NFTState.Redeemed) revert PositionAlreadyRedeemed();
+        QueueLib.NFTPosition storage pos = positions[positionIndex];
+        if (pos.state == QueueLib.NFTState.Redeemed) revert PositionAlreadyRedeemed();
+
+        _syncMaturities(MAX_MATURITY_SYNC);
 
         IDecentralPool pool = positionPool[positionIndex];
 
         // Active → YieldWithdrawalRequested
         if (
-            pos.state == NFTState.Active && block.timestamp >= pos.maturityTime
+            pos.state == QueueLib.NFTState.Active && block.timestamp >= pos.maturityTime
         ) {
-            // Cap-at-maturity (audit H-01): if the position hasn't already been
-            // capped via cleanMaturedFromBucket, do it inline now. Decentral
-            // stops paying yield at maturityTime, so any accrual past maturity
-            // is phantom and must be excluded before we move the position to
-            // YieldWithdrawalRequested — otherwise totalPendingYield would
-            // record the inflated value and shareholders would absorb the
-            // shortfall at executeYieldWithdrawal time.
-            if (pos.pendingYield == 0) {
-                _capYieldAtMaturity(positionIndex);
-            }
+            // The chronological heap sync above must have capped this position
+            // before its Decentral lifecycle can advance. A larger overdue
+            // backlog is drained over subsequent permissionless calls.
+            if (!pos.yieldCapped) return;
 
-            // Wrapped in try/catch like every other Decentral interaction in
-            // this function — without it, a paused/shutdown Decentral pool at
-            // a position's maturity would revert the whole call and leave the
-            // position permanently stuck.
-            try pool.requestYieldWithdrawal(pos.tokenId) {
-                // Bucket bookkeeping (yield removal, pendingYield, and
-                // totalPendingYield bump) was already handled by
-                // _capYieldAtMaturity above. Just promote the state.
-                pos.state = NFTState.YieldWithdrawalRequested;
+            // A zero-APY or dust-rounded position has no yield withdrawal to
+            // request. Skip directly to the principal path; using pendingYield
+            // itself as the cap marker would leave this position stuck Active.
+            if (pos.pendingYield == 0) {
+                pos.state = QueueLib.NFTState.YieldClaimed;
                 emit PositionProcessed(
                     positionIndex,
                     pos.tokenId,
                     uint8(pos.state)
                 );
-            } catch {
-                // Decentral may be paused/shutdown — no-op so the position
-                // stays Active. The cap remains locked in (pendingYield set,
-                // bucket cleared) so totalAssets() stays flat; the next
-                // pokeDecentral call retries the Decentral request and skips
-                // the cap step since pendingYield is already non-zero.
-                return;
+            } else {
+                // Wrapped in try/catch like every other Decentral interaction
+                // so a paused/shutdown pool can be retried later.
+                try pool.requestYieldWithdrawal(pos.tokenId) {
+                    pos.state = QueueLib.NFTState.YieldWithdrawalRequested;
+                    emit PositionProcessed(
+                        positionIndex,
+                        pos.tokenId,
+                        uint8(pos.state)
+                    );
+                } catch {
+                    // The cap remains locked in while the request is retried.
+                    return;
+                }
             }
         }
 
         // YieldWithdrawalRequested → YieldClaimed
-        if (pos.state == NFTState.YieldWithdrawalRequested) {
+        if (pos.state == QueueLib.NFTState.YieldWithdrawalRequested) {
             uint256 balBefore = hollar.balanceOf(address(this));
             uint256 expectedYield = pos.pendingYield;
             uint256 yieldReceived;
-            bool yieldExecuted;
             try pool.executeYieldWithdrawal(pos.tokenId) {
                 yieldReceived = hollar.balanceOf(address(this)) - balBefore;
 
@@ -792,13 +778,12 @@ contract BILVault is
                 pos.pendingYield = 0;
                 idleHollar += yieldReceived;
 
-                pos.state = NFTState.YieldClaimed;
+                pos.state = QueueLib.NFTState.YieldClaimed;
                 emit PositionProcessed(
                     positionIndex,
                     pos.tokenId,
                     uint8(pos.state)
                 );
-                yieldExecuted = true;
             } catch {
                 // Not yet approved by Decentral — no-op, retry next cycle
                 return;
@@ -808,11 +793,7 @@ contract BILVault is
             // propagates up. Only a shortfall trips it; surplus is benign and
             // lifts the rate. Skipped when expectedYield is zero (no pending
             // yield to compare against, e.g., dust-rounded positions).
-            if (
-                yieldExecuted &&
-                expectedYield > 0 &&
-                yieldReceived < expectedYield
-            ) {
+            if (expectedYield > 0 && yieldReceived < expectedYield) {
                 uint256 shortfallBps = ((expectedYield - yieldReceived) *
                     10_000) / expectedYield;
                 if (shortfallBps > principalMismatchBpsThreshold) {
@@ -827,9 +808,9 @@ contract BILVault is
         }
 
         // YieldClaimed → PrincipalWithdrawalRequested
-        if (pos.state == NFTState.YieldClaimed) {
+        if (pos.state == QueueLib.NFTState.YieldClaimed) {
             try pool.requestPrincipalWithdrawal(pos.tokenId) {
-                pos.state = NFTState.PrincipalWithdrawalRequested;
+                pos.state = QueueLib.NFTState.PrincipalWithdrawalRequested;
                 emit PositionProcessed(
                     positionIndex,
                     pos.tokenId,
@@ -842,11 +823,10 @@ contract BILVault is
         }
 
         // PrincipalWithdrawalRequested → Redeemed
-        if (pos.state == NFTState.PrincipalWithdrawalRequested) {
+        if (pos.state == QueueLib.NFTState.PrincipalWithdrawalRequested) {
             uint256 balBefore = hollar.balanceOf(address(this));
             uint256 expectedPrincipal = pos.principal;
             uint256 principalReceived;
-            bool principalExecuted;
             try pool.executePrincipalWithdrawal(pos.tokenId) {
                 principalReceived = hollar.balanceOf(address(this)) - balBefore;
 
@@ -872,7 +852,7 @@ contract BILVault is
                 _removePrincipalFromBucket(expectedPrincipal);
 
                 idleHollar += principalReceived;
-                pos.state = NFTState.Redeemed;
+                pos.state = QueueLib.NFTState.Redeemed;
                 _advancePositionHead();
 
                 emit PositionRedeemed(
@@ -883,11 +863,14 @@ contract BILVault is
                 );
 
                 // Distribute available HOLLAR to queue
-                if (totalQueuedBil > 0 && idleHollar > 0) {
+                if (
+                    totalQueuedBil > 0 &&
+                    idleHollar > 0 &&
+                    !_hasMaturedBacklog()
+                ) {
                     uint256 rate = exchangeRate();
                     _processQueueWithHollar(idleHollar, rate);
                 }
-                principalExecuted = true;
             } catch {
                 // Not yet approved or delay not elapsed — no-op
                 return;
@@ -899,11 +882,7 @@ contract BILVault is
             // state and bucket changes above), so the vault refuses to absorb
             // a catastrophic shock atomically. Operations can pause and
             // investigate before retrying.
-            if (
-                principalExecuted &&
-                expectedPrincipal > 0 &&
-                principalReceived < expectedPrincipal
-            ) {
+            if (principalReceived < expectedPrincipal) {
                 uint256 shortfallBps = ((expectedPrincipal -
                     principalReceived) * 10_000) / expectedPrincipal;
                 if (shortfallBps > principalMismatchBpsThreshold) {
@@ -918,48 +897,20 @@ contract BILVault is
         }
     }
 
-    /// @notice Cap a matured position's yield accrual at `maturityTime`
-    ///         WITHOUT advancing its Decentral lifecycle (audit H-01).
-    /// @dev Permissionless. For any `Active` position past `maturityTime` that
-    ///      has not yet been moved to `YieldWithdrawalRequested`, this freezes
-    ///      the yield contribution at the maturity-capped amount, removes the
-    ///      position from the live yield bucket, and locks the capped amount
-    ///      into `totalPendingYield`.
-    ///
-    ///      Why this exists: `totalAssets()` derives accrued yield from the
-    ///      aggregate `(block.timestamp * yieldRateSum - yieldOffsetSum)`,
-    ///      which grows linearly with `block.timestamp` and has no per-position
-    ///      maturity awareness. Real Decentral stops paying yield at
-    ///      `maturityTime`, so a position that lingers in `Active` past
-    ///      maturity (e.g., a delayed keeper) silently inflates the rate.
-    ///      Anyone — a keeper bot, an arbitrage-prevention bot, or a user
-    ///      about to redeem — may call this atomically before any rate-sensitive
-    ///      operation to lock the bucket at the honest value.
-    ///
-    ///      Idempotent: if the position is already capped (`pendingYield != 0`
-    ///      while still `Active`) or has moved past `Active`, the call is a
-    ///      no-op. Reverts only when the position is not yet past maturity, so
-    ///      callers can probe safely.
-    /// @param positionIndex Index of the position in `positions`
-    function cleanMaturedFromBucket(uint256 positionIndex) external nonReentrant whenNotPaused {
-        NFTPosition storage pos = positions[positionIndex];
-        // Only cap positions still in Active state — past that, the bucket
-        // has already been settled and pendingYield/totalPendingYield manage
-        // accounting until execute.
-        if (pos.state != NFTState.Active) return;
-        // Already capped — no-op (idempotent).
-        if (pos.pendingYield != 0) return;
-        // Refuse to cap pre-maturity positions: bucket math is correct for
-        // live positions and the per-position storage would be wasted.
-        if (block.timestamp < pos.maturityTime) return;
-
-        _capYieldAtMaturity(positionIndex);
+    /// @notice Permissionlessly cap up to `maxPositions` due maturities in
+    ///         chronological order. Safe to call while the vault is paused.
+    /// @dev Deposits and mints remain disabled while any due root remains.
+    function syncMaturities(
+        uint256 maxPositions
+    ) external returns (uint256 processed) {
+        processed = _syncMaturities(maxPositions);
     }
 
     /// @notice Process queued redemptions, then reinvest remaining idle HOLLAR
     /// @dev Callable by anyone (bot or user). Processes first MAX_QUEUE_ITERATIONS withdrawals,
     ///      then reinvests remaining idle HOLLAR if the queue couldn't progress.
     function pokeQueue() external nonReentrant whenNotPaused {
+        _syncBeforeRateSensitiveAction();
         uint256 rate = exchangeRate();
 
         // Always invoke the queue processor. With funds, it processes redemptions;
@@ -1043,28 +994,7 @@ contract BILVault is
         }
         if (amount < minReinvestAmount) return;
 
-        IDecentralPool pool = activeDepositPool;
-        uint256 apyWad = pool.fixedAPYWad();
-        hollar.safeApprove(address(pool), 0);
-        hollar.safeApprove(address(pool), amount);
-        uint256 tokenId = pool.deposit(amount);
-
-        uint256 idx = positions.length;
-        positions.push(
-            NFTPosition({
-                tokenId: tokenId,
-                principal: amount,
-                apyWad: apyWad,
-                depositTime: block.timestamp,
-                maturityTime: block.timestamp + _investmentPeriod(pool),
-                yieldStartTime: block.timestamp,
-                state: NFTState.Active,
-                pendingYield: 0
-            })
-        );
-        positionPool[idx] = pool;
-
-        _addToBucket(apyWad, amount, block.timestamp);
+        uint256 tokenId = _depositIntoDecentral(amount);
         idleHollar -= amount;
 
         emit Reinvested(amount, tokenId);
@@ -1097,11 +1027,11 @@ contract BILVault is
     }
 
     /// @notice Max HOLLAR `receiver` can deposit right now.
-    /// @dev    Returns 0 if deposits are paused (at either level) or if the
-    ///         TVL cap is already reached. Otherwise the remaining headroom
-    ///         under the cap.
+    /// @dev    Returns 0 if deposits are paused, a maturity checkpoint is due,
+    ///         or the TVL cap is already reached. Otherwise returns the
+    ///         remaining headroom under the cap.
     function maxDeposit(address /* receiver */) public view returns (uint256) {
-        if (paused() || depositsPaused) return 0;
+        if (paused() || depositsPaused || _hasMaturedBacklog()) return 0;
         uint256 totalA = totalAssets();
         if (totalA >= tvlCap) return 0;
         return tvlCap - totalA;
@@ -1119,27 +1049,24 @@ contract BILVault is
     ///         cancel-spam DoS). Per ERC-7540 §maxRedeem/maxWithdraw, returns
     ///         the value of all settled-but-unclaimed requests for the caller.
     function maxWithdraw(address controller) external view returns (uint256 max) {
-        uint256[] storage ids = _settledByController[controller];
-        uint256 len = ids.length;
-        for (uint256 i = 0; i < len; i++) {
-            QueueLib.Request storage r = redemptionQueue[ids[i]];
-            // Defensive: the index may briefly hold stale entries that claim
-            // hasn't swap-popped yet. Filter on user match keeps the answer
-            // accurate without requiring eager index pruning.
-            if (r.user == controller) max += r.hollarOwed;
-        }
+        return QueueLib.sumSettled(
+            redemptionQueue,
+            _settledByController[controller],
+            controller,
+            true
+        );
     }
 
     /// @notice ERC-7540 `maxRedeem`: total hDCL currently claimable by
     ///         `controller` across all of their settled requests. Same
     ///         iteration bound as `maxWithdraw`.
     function maxRedeem(address controller) external view returns (uint256 max) {
-        uint256[] storage ids = _settledByController[controller];
-        uint256 len = ids.length;
-        for (uint256 i = 0; i < len; i++) {
-            QueueLib.Request storage r = redemptionQueue[ids[i]];
-            if (r.user == controller) max += r.bilSettled;
-        }
+        return QueueLib.sumSettled(
+            redemptionQueue,
+            _settledByController[controller],
+            controller,
+            false
+        );
     }
 
     /// @notice Preview how much HOLLAR is needed to mint exactly `shares` hDCL.
@@ -1237,49 +1164,19 @@ contract BILVault is
     function getEstimatedWaitTime(
         uint256 requestId
     ) external view returns (uint256 estimatedSeconds) {
-        QueueLib.Request storage request = redemptionQueue[requestId];
-        if (request.user == address(0)) return 0;
-
-        uint256 rate = exchangeRate();
-
-        // Sum total HOLLAR needed for all queue entries ahead of and including this request
-        uint256 hollarNeeded = 0;
-        for (uint256 i = queueHead; i <= requestId; i++) {
-            QueueLib.Request storage r = redemptionQueue[i];
-            if (r.user == address(0)) continue;
-            uint256 remainingBil = r.bilAmount - r.bilSettled;
-            hollarNeeded += (remainingBil * rate) / WAD;
-        }
-
-        // Subtract currently available idle HOLLAR
-        if (idleHollar >= hollarNeeded) return 0;
-        hollarNeeded -= idleHollar;
-
-        // Walk through positions to find when enough matures
-        uint256 accumulated = 0;
-        for (uint256 i = positionHead; i < positions.length; i++) {
-            NFTPosition storage pos = positions[i];
-            if (pos.state == NFTState.Redeemed) continue;
-
-            // Expected return: principal + yield.
-            uint256 expectedYield = (pos.principal *
-                pos.apyWad *
-                (pos.maturityTime - pos.yieldStartTime)) /
-                (SECONDS_PER_YEAR * WAD);
-            accumulated += pos.principal + expectedYield;
-
-            if (accumulated >= hollarNeeded) {
-                uint256 maturityWithDelay = pos.maturityTime +
-                    _decentralWithdrawalDelay(positionPool[i]);
-                if (maturityWithDelay > block.timestamp) {
-                    return maturityWithDelay - block.timestamp;
-                }
-                return 0;
-            }
-        }
-
-        // If we can't cover it with known positions, return max estimate
-        return type(uint256).max;
+        return QueueLib.estimatedWaitTime(
+            redemptionQueue,
+            positions,
+            positionPool,
+            requestId,
+            queueHead,
+            positionHead,
+            exchangeRate(),
+            WAD,
+            idleHollar,
+            SECONDS_PER_YEAR * WAD,
+            block.timestamp
+        );
     }
 
     /// @notice Get redemption request details
@@ -1315,7 +1212,7 @@ contract BILVault is
             uint8 state
         )
     {
-        NFTPosition storage pos = positions[positionIndex];
+        QueueLib.NFTPosition storage pos = positions[positionIndex];
         return (
             pos.tokenId,
             pos.principal,
@@ -1377,16 +1274,7 @@ contract BILVault is
     ///           - `answeredInRound >= roundId` — answer isn't carry-over
     ///             from a prior round (stale data).
     function getOraclePrice() external view returns (uint256) {
-        if (address(oracle) == address(0)) revert OracleNotSet();
-        (uint80 roundId, int256 answer, , uint256 updatedAt, uint80 answeredInRound) =
-            oracle.latestRoundData();
-        if (answer <= 0) revert OracleInvalidAnswer();
-        if (roundId == 0) revert OracleRoundIncomplete();
-        if (updatedAt == 0) revert OracleRoundIncomplete();
-        if (answeredInRound < roundId) revert OracleStaleRound();
-
-        uint8 oracleDecimals = oracle.decimals();
-        return (uint256(answer) * WAD) / (10 ** oracleDecimals);
+        return QueueLib.oraclePrice(oracle);
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -1473,11 +1361,7 @@ contract BILVault is
         if (_oracle == address(0)) revert ZeroAddress();
 
         IAggregatorV3Interface candidate = IAggregatorV3Interface(_oracle);
-        (, int256 answer, , uint256 updatedAt, ) = candidate.latestRoundData();
-        if (answer <= 0) revert OracleInvalidAnswer();
-        if (updatedAt == 0) revert OracleRoundIncomplete();
-        uint8 d = candidate.decimals();
-        if (d < 6 || d > 18) revert OracleDecimalsOutOfRange();
+        QueueLib.validateOracle(candidate);
 
         oracle = candidate;
         emit OracleUpdated(_oracle);
@@ -1532,29 +1416,16 @@ contract BILVault is
         if (!isPoolRegistered[pool]) revert PoolNotRegistered();
         if (pool == activeDepositPool) revert CannotRetireActivePool();
 
-        // Reject if any non-redeemed position references this pool.
-        uint256 len = positions.length;
-        for (uint256 i = positionHead; i < len; i++) {
-            if (
-                positions[i].state != NFTState.Redeemed &&
-                positionPool[i] == pool
-            ) {
-                revert PoolHasOpenPositions();
-            }
-        }
+        QueueLib.removePool(
+            positions,
+            positionPool,
+            pools,
+            positionHead,
+            pool
+        );
 
         isPoolRegistered[pool] = false;
         isRegisteredPoolToken[address(pool.poolToken())] = false;
-
-        // Swap-and-pop from pools[]
-        uint256 plen = pools.length;
-        for (uint256 i = 0; i < plen; i++) {
-            if (pools[i] == pool) {
-                pools[i] = pools[plen - 1];
-                pools.pop();
-                break;
-            }
-        }
 
         emit PoolRetired(address(pool));
     }
@@ -1570,18 +1441,14 @@ contract BILVault is
     ///      param (which would otherwise be unused). Pass `address(0)` to
     ///      skip the assertion.
     function _registerPool(IDecentralPool newPool, address expectedPoolToken) internal {
-        if (address(newPool) == address(0)) revert ZeroAddress();
-        if (isPoolRegistered[newPool]) revert PoolAlreadyRegistered();
-        if (address(newPool.stablecoin()) != address(hollar)) revert PoolWrongStablecoin();
-        address poolTokenAddr = address(newPool.poolToken());
-        if (poolTokenAddr == address(0)) revert PoolNoNFTContract();
-        if (expectedPoolToken != address(0)) {
-            if (poolTokenAddr != expectedPoolToken) revert PoolTokenMismatch();
-        }
-
-        isPoolRegistered[newPool] = true;
-        isRegisteredPoolToken[poolTokenAddr] = true;
-        pools.push(newPool);
+        QueueLib.registerPool(
+            isPoolRegistered,
+            isRegisteredPoolToken,
+            pools,
+            newPool,
+            address(hollar),
+            expectedPoolToken
+        );
 
         emit PoolRegistered(address(newPool));
     }
@@ -1653,22 +1520,17 @@ contract BILVault is
 
     /// @dev Advance positionHead past redeemed positions
     function _advancePositionHead() internal {
-        uint256 head = positionHead;
-        uint256 len = positions.length;
-        uint256 swept;
-        while (
-            head < len &&
-            positions[head].state == NFTState.Redeemed &&
-            swept < MAX_POSITION_HEAD_SWEEP
-        ) {
-            unchecked { head++; swept++; }
-        }
-        positionHead = head;
+        positionHead = QueueLib.advancePositionHead(
+            positions,
+            positionHead,
+            MAX_POSITION_HEAD_SWEEP
+        );
     }
 
     /// @dev Record a fresh position: bump principal counter and add to the
     ///      yield aggregates. Used by deposit and reinvest paths.
     function _addToBucket(
+        uint256 positionIndex,
         uint256 apyWad,
         uint256 principal,
         uint256 yieldStartTime
@@ -1676,41 +1538,47 @@ contract BILVault is
         totalInvestedPrincipal += principal;
         yieldRateSum += apyWad * principal;
         yieldOffsetSum += apyWad * principal * yieldStartTime;
-    }
-
-    /// @dev Cap a position's yield at `maturityTime` and freeze it into
-    ///      `pendingYield` / `totalPendingYield` (audit H-01).
-    ///      Pre-conditions enforced by callers:
-    ///        - pos.state == Active
-    ///        - pos.pendingYield == 0 (not yet capped)
-    ///        - block.timestamp >= pos.maturityTime
-    ///      Removes the position's contribution from the live yield bucket so
-    ///      `totalAssets()` no longer over-counts virtual post-maturity yield.
-    function _capYieldAtMaturity(uint256 positionIndex) internal {
-        NFTPosition storage pos = positions[positionIndex];
-        uint256 capped = (pos.principal *
-            pos.apyWad *
-            (pos.maturityTime - pos.yieldStartTime)) /
-            (SECONDS_PER_YEAR * WAD);
-        pos.pendingYield = capped;
-        totalPendingYield += capped;
-        _removeYieldFromBucket(
-            pos.apyWad,
-            pos.principal,
-            pos.yieldStartTime
+        QueueLib.pushMaturity(
+            _maturityHeap,
+            positions[positionIndex].maturityTime,
+            positionIndex
         );
     }
 
-    /// @dev Stop a position from accruing yield without touching its principal.
-    ///      Used at Active → YieldWithdrawalRequested when Decentral has locked
-    ///      the payout amount.
-    function _removeYieldFromBucket(
-        uint256 apyWad,
-        uint256 principal,
-        uint256 yieldStartTime
-    ) internal {
-        yieldRateSum -= apyWad * principal;
-        yieldOffsetSum -= apyWad * principal * yieldStartTime;
+    function _syncMaturities(
+        uint256 maxPositions
+    ) internal returns (uint256 processed) {
+        uint256 newRateSum;
+        uint256 newOffsetSum;
+        uint256 pendingAdded;
+        (processed, newRateSum, newOffsetSum, pendingAdded) =
+            QueueLib.processMaturities(
+                positions,
+                _maturityHeap,
+                maxPositions,
+                block.timestamp,
+                yieldRateSum,
+                yieldOffsetSum,
+                SECONDS_PER_YEAR * WAD
+            );
+        yieldRateSum = newRateSum;
+        yieldOffsetSum = newOffsetSum;
+        totalPendingYield += pendingAdded;
+    }
+
+    function _syncBeforeRateSensitiveAction() internal {
+        _syncMaturities(MAX_MATURITY_SYNC);
+        _requireNoMaturityBacklog();
+    }
+
+    function _requireNoMaturityBacklog() internal view {
+        if (_hasMaturedBacklog()) revert MaturityBacklog();
+    }
+
+    function _hasMaturedBacklog() internal view returns (bool) {
+        return
+            _maturityHeap.length > 0 &&
+            (_maturityHeap[0] >> 128) <= block.timestamp;
     }
 
     /// @dev Drop a position's principal contribution after Decentral has paid
@@ -1722,11 +1590,6 @@ contract BILVault is
     /// @dev Returns the minimum investment period from a specific Decentral pool
     function _investmentPeriod(IDecentralPool pool) internal view returns (uint256) {
         return pool.minimumInvestmentPeriodSeconds();
-    }
-
-    /// @dev Returns the principal withdrawal delay from a specific Decentral pool
-    function _decentralWithdrawalDelay(IDecentralPool pool) internal view returns (uint256) {
-        return pool.principalWithdrawalDelaySeconds();
     }
 
     /// @dev Authorize UUPS upgrade — only UPGRADER_ROLE
@@ -1769,10 +1632,13 @@ contract BILVault is
     ///         Default 100 (1%). Bounded to [0, 10_000].
     uint256 public principalMismatchBpsThreshold;
 
+    /// @dev Min-heap of packed (maturityTime, positionIndex) entries.
+    uint256[] private _maturityHeap;
+
     // ═══════════════════════════════════════════════════════════════════════
     //                         STORAGE GAP
     // ═══════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades.
-    uint256[48] private __gap;
+    uint256[47] private __gap;
 }

--- a/bil-vault/src/BILVault.sol
+++ b/bil-vault/src/BILVault.sol
@@ -351,6 +351,10 @@ contract BILVault is
     );
     error BpsAboveMax();
     error MaturityBacklog();
+    /// @dev A new position would break the non-decreasing maturity ordering the
+    ///      `checkpointHead` clamp relies on (e.g. switching to a shorter-period
+    ///      pool while older positions are still active).
+    error NonMonotonicMaturity();
 
     // ═══════════════════════════════════════════════════════════════════════
     //                         INITIALIZER
@@ -412,12 +416,15 @@ contract BILVault is
     function totalAssets() public view returns (uint256) {
         uint256 accruedYield = 0;
         if (yieldRateSum > 0) {
-            // An overdue heap root clamps the entire live aggregate. Later
-            // positions may be conservatively under-counted until sync, but
-            // phantom post-maturity yield is impossible even without a keeper.
+            // The earliest un-checkpointed maturity clamps the entire live
+            // aggregate. Positions are appended in non-decreasing maturity
+            // order (enforced in _addToBucket), so positions[checkpointHead]
+            // is that earliest one. Later positions may be conservatively
+            // under-counted until sync, but phantom post-maturity yield is
+            // impossible even without a keeper.
             uint256 accrualTime = block.timestamp;
-            if (_maturityHeap.length > 0) {
-                uint256 earliest = _maturityHeap[0] >> 128;
+            if (checkpointHead < positions.length) {
+                uint256 earliest = positions[checkpointHead].maturityTime;
                 if (earliest < accrualTime) accrualTime = earliest;
             }
             uint256 gross = accrualTime * yieldRateSum;
@@ -729,7 +736,7 @@ contract BILVault is
         if (
             pos.state == QueueLib.NFTState.Active && block.timestamp >= pos.maturityTime
         ) {
-            // The chronological heap sync above must have capped this position
+            // The chronological sync above must have capped this position
             // before its Decentral lifecycle can advance. A larger overdue
             // backlog is drained over subsequent permissionless calls.
             if (!pos.yieldCapped) return;
@@ -1528,42 +1535,53 @@ contract BILVault is
     }
 
     /// @dev Record a fresh position: bump principal counter and add to the
-    ///      yield aggregates. Used by deposit and reinvest paths.
+    ///      yield aggregates. Used by deposit and reinvest paths. Called right
+    ///      after the position is pushed, so `positions[positionIndex]` is it.
     function _addToBucket(
         uint256 positionIndex,
         uint256 apyWad,
         uint256 principal,
         uint256 yieldStartTime
     ) internal {
+        // Enforce the non-decreasing maturity invariant the checkpointHead
+        // clamp relies on: the new position must not mature before its
+        // predecessor. Holds automatically for a single pool with a constant
+        // investment period; fails loudly if a shorter-period pool is switched
+        // in while older positions are still live.
+        if (
+            positionIndex > 0 &&
+            positions[positionIndex].maturityTime <
+            positions[positionIndex - 1].maturityTime
+        ) revert NonMonotonicMaturity();
+
         totalInvestedPrincipal += principal;
         yieldRateSum += apyWad * principal;
         yieldOffsetSum += apyWad * principal * yieldStartTime;
-        QueueLib.pushMaturity(
-            _maturityHeap,
-            positions[positionIndex].maturityTime,
-            positionIndex
-        );
     }
 
     function _syncMaturities(
         uint256 maxPositions
     ) internal returns (uint256 processed) {
+        uint256 startHead = checkpointHead;
+        uint256 newHead;
         uint256 newRateSum;
         uint256 newOffsetSum;
         uint256 pendingAdded;
-        (processed, newRateSum, newOffsetSum, pendingAdded) =
+        (newHead, newRateSum, newOffsetSum, pendingAdded) =
             QueueLib.processMaturities(
                 positions,
-                _maturityHeap,
+                checkpointHead,
                 maxPositions,
                 block.timestamp,
                 yieldRateSum,
                 yieldOffsetSum,
                 SECONDS_PER_YEAR * WAD
             );
+        checkpointHead = newHead;
         yieldRateSum = newRateSum;
         yieldOffsetSum = newOffsetSum;
         totalPendingYield += pendingAdded;
+        processed = newHead - startHead;
     }
 
     function _syncBeforeRateSensitiveAction() internal {
@@ -1575,10 +1593,11 @@ contract BILVault is
         if (_hasMaturedBacklog()) revert MaturityBacklog();
     }
 
+    /// @dev True while the earliest un-checkpointed position is already due.
     function _hasMaturedBacklog() internal view returns (bool) {
         return
-            _maturityHeap.length > 0 &&
-            (_maturityHeap[0] >> 128) <= block.timestamp;
+            checkpointHead < positions.length &&
+            positions[checkpointHead].maturityTime <= block.timestamp;
     }
 
     /// @dev Drop a position's principal contribution after Decentral has paid
@@ -1632,8 +1651,13 @@ contract BILVault is
     ///         Default 100 (1%). Bounded to [0, 10_000].
     uint256 public principalMismatchBpsThreshold;
 
-    /// @dev Min-heap of packed (maturityTime, positionIndex) entries.
-    uint256[] private _maturityHeap;
+    /// @notice Index of the earliest position whose yield has NOT yet been
+    ///         checkpointed at maturity (audit H-01). Everything below it is
+    ///         capped; `positions[checkpointHead]` is the earliest still
+    ///         contributing live yield, so `totalAssets()` clamps accrual there.
+    ///         Monotonic; advanced only by `syncMaturities`. Valid because
+    ///         positions are appended in non-decreasing maturity order.
+    uint256 public checkpointHead;
 
     // ═══════════════════════════════════════════════════════════════════════
     //                         STORAGE GAP

--- a/bil-vault/src/interfaces/IBILVault.sol
+++ b/bil-vault/src/interfaces/IBILVault.sol
@@ -110,6 +110,7 @@ interface IBILVault {
     // ──────────────────────────────────────────────
 
     function pokeDecentral(uint256 positionIndex) external;
+    function syncMaturities(uint256 maxPositions) external returns (uint256 processed);
     function pokeQueue() external;
 
     // ──────────────────────────────────────────────

--- a/bil-vault/src/libraries/QueueLib.sol
+++ b/bil-vault/src/libraries/QueueLib.sol
@@ -1,16 +1,37 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.22;
 
+import {IDecentralPool} from "../interfaces/IDecentralPool.sol";
+import {IAggregatorV3Interface} from "../interfaces/IAggregatorV3Interface.sol";
+
 /// @title QueueLib
-/// @notice FIFO redemption queue mechanics extracted from BILVault to keep
-///         the vault under EIP-170. All three functions are `public` so they
-///         deploy as a separate library contract and the vault DELEGATECALLs
-///         them — saving ~3 KB on the vault's deployed bytecode.
-/// @dev    Library functions do NOT touch `idleHollar` or `totalReservedHollar`
-///         directly — those live on the vault. Library returns deltas; the
-///         vault applies them. This keeps the storage write surface explicit
-///         in the calling contract for audit clarity.
+/// @notice Shared BILVault mechanics deployed as a linked library to keep the
+///         vault below EIP-170. Storage-bearing helpers receive each storage
+///         reference explicitly; accounting helpers return aggregate deltas
+///         for the vault to apply at the call boundary.
 library QueueLib {
+    uint256 private constant MATURITY_SHIFT = 128;
+
+    enum NFTState {
+        Active,
+        YieldWithdrawalRequested,
+        YieldClaimed,
+        PrincipalWithdrawalRequested,
+        Redeemed
+    }
+
+    struct NFTPosition {
+        uint256 tokenId;
+        uint256 principal;
+        uint256 apyWad;
+        uint256 depositTime;
+        uint256 maturityTime;
+        uint256 yieldStartTime;
+        NFTState state;
+        bool yieldCapped;
+        uint256 pendingYield;
+    }
+
     /// @notice A queued redemption request.
     struct Request {
         address user;          // controller (= owner under standard flow)
@@ -20,6 +41,17 @@ library QueueLib {
     }
 
     error InsufficientClaimable();
+    error PoolHasOpenPositions();
+    error ZeroAddress();
+    error PoolAlreadyRegistered();
+    error PoolWrongStablecoin();
+    error PoolNoNFTContract();
+    error PoolTokenMismatch();
+    error OracleNotSet();
+    error OracleInvalidAnswer();
+    error OracleRoundIncomplete();
+    error OracleStaleRound();
+    error OracleDecimalsOutOfRange();
 
     event RedemptionFulfilled(
         uint256 indexed requestId,
@@ -33,6 +65,262 @@ library QueueLib {
         uint256 hollarAmount,
         uint256 bilBurned
     );
+    event PositionYieldCapped(
+        uint256 indexed positionIndex,
+        uint256 maturityTime,
+        uint256 pendingYield
+    );
+
+    /// @notice Add a packed `(maturity, positionIndex)` entry to the min-heap.
+    /// @dev Kept in the linked library so heap maintenance does not consume
+    ///      the vault's EIP-170 bytecode budget.
+    function pushMaturity(
+        uint256[] storage heap,
+        uint256 maturityTime,
+        uint256 positionIndex
+    ) public {
+        require(maturityTime <= type(uint128).max, "maturity overflow");
+        require(positionIndex <= type(uint128).max, "position overflow");
+        uint256 entry = (maturityTime << MATURITY_SHIFT) | positionIndex;
+        heap.push(entry);
+        uint256 cursor = heap.length - 1;
+        while (cursor > 0) {
+            uint256 parent = (cursor - 1) / 2;
+            if (heap[parent] <= entry) break;
+            heap[cursor] = heap[parent];
+            cursor = parent;
+        }
+        heap[cursor] = entry;
+    }
+
+    /// @notice Cap up to `maxPositions` due heap roots and return aggregate
+    ///         accounting deltas to the vault.
+    function processMaturities(
+        NFTPosition[] storage positions,
+        uint256[] storage heap,
+        uint256 maxPositions,
+        uint256 timestamp,
+        uint256 rateSum,
+        uint256 offsetSum,
+        uint256 denominator
+    )
+        public
+        returns (
+            uint256 processed,
+            uint256 newRateSum,
+            uint256 newOffsetSum,
+            uint256 pendingYieldAdded
+        )
+    {
+        newRateSum = rateSum;
+        newOffsetSum = offsetSum;
+        while (processed < maxPositions && heap.length > 0) {
+            uint256 entry = heap[0];
+            uint256 maturityTime = entry >> MATURITY_SHIFT;
+            if (maturityTime > timestamp) break;
+            uint256 positionIndex = uint128(entry);
+
+            _popMaturity(heap);
+            NFTPosition storage pos = positions[positionIndex];
+            uint256 rate = pos.apyWad * pos.principal;
+            uint256 capped = (rate * (maturityTime - pos.yieldStartTime)) /
+                denominator;
+            pos.pendingYield = capped;
+            pos.yieldCapped = true;
+            newRateSum -= rate;
+            newOffsetSum -= rate * pos.yieldStartTime;
+            pendingYieldAdded += capped;
+            emit PositionYieldCapped(positionIndex, maturityTime, capped);
+            unchecked { ++processed; }
+        }
+    }
+
+    function _popMaturity(uint256[] storage heap) private {
+        uint256 lastIndex = heap.length - 1;
+        uint256 last = heap[lastIndex];
+        heap.pop();
+        if (lastIndex == 0) return;
+
+        uint256 cursor;
+        uint256 len = heap.length;
+        while (true) {
+            uint256 left = cursor * 2 + 1;
+            if (left >= len) break;
+            uint256 right = left + 1;
+            uint256 smallest = right < len && heap[right] < heap[left]
+                ? right
+                : left;
+            if (heap[smallest] >= last) break;
+            heap[cursor] = heap[smallest];
+            cursor = smallest;
+        }
+        heap[cursor] = last;
+    }
+
+    function estimatedWaitTime(
+        mapping(uint256 => Request) storage queue,
+        NFTPosition[] storage positions,
+        mapping(uint256 => IDecentralPool) storage positionPool,
+        uint256 requestId,
+        uint256 queueHead,
+        uint256 positionHead,
+        uint256 rate,
+        uint256 wad,
+        uint256 idleHollar,
+        uint256 denominator,
+        uint256 timestamp
+    ) public view returns (uint256) {
+        if (queue[requestId].user == address(0)) return 0;
+
+        uint256 hollarNeeded;
+        for (uint256 i = queueHead; i <= requestId; i++) {
+            Request storage r = queue[i];
+            if (r.user == address(0)) continue;
+            hollarNeeded += ((r.bilAmount - r.bilSettled) * rate) / wad;
+        }
+        if (idleHollar >= hollarNeeded) return 0;
+        hollarNeeded -= idleHollar;
+
+        uint256 accumulated;
+        for (uint256 i = positionHead; i < positions.length; i++) {
+            NFTPosition storage pos = positions[i];
+            if (pos.state == NFTState.Redeemed) continue;
+            uint256 expectedYield = (pos.principal *
+                pos.apyWad *
+                (pos.maturityTime - pos.yieldStartTime)) / denominator;
+            accumulated += pos.principal + expectedYield;
+            if (accumulated >= hollarNeeded) {
+                uint256 readyAt = pos.maturityTime +
+                    positionPool[i].principalWithdrawalDelaySeconds();
+                return readyAt > timestamp ? readyAt - timestamp : 0;
+            }
+        }
+        return type(uint256).max;
+    }
+
+    function sumSettled(
+        mapping(uint256 => Request) storage queue,
+        uint256[] storage ids,
+        address controller,
+        bool assets
+    ) public view returns (uint256 total) {
+        uint256 len = ids.length;
+        for (uint256 i = 0; i < len; i++) {
+            Request storage r = queue[ids[i]];
+            if (r.user == controller) {
+                total += assets ? r.hollarOwed : r.bilSettled;
+            }
+        }
+    }
+
+    function advanceQueueHead(
+        mapping(uint256 => Request) storage queue,
+        uint256 head,
+        uint256 tail,
+        uint256 maxIterations
+    ) public view returns (uint256) {
+        uint256 swept;
+        while (
+            head < tail &&
+            swept < maxIterations &&
+            queue[head].user == address(0)
+        ) {
+            unchecked { ++head; ++swept; }
+        }
+        return head;
+    }
+
+    function advancePositionHead(
+        NFTPosition[] storage positions,
+        uint256 head,
+        uint256 maxIterations
+    ) public view returns (uint256) {
+        uint256 len = positions.length;
+        uint256 swept;
+        while (
+            head < len &&
+            swept < maxIterations &&
+            positions[head].state == NFTState.Redeemed
+        ) {
+            unchecked { ++head; ++swept; }
+        }
+        return head;
+    }
+
+    function removePool(
+        NFTPosition[] storage positions,
+        mapping(uint256 => IDecentralPool) storage positionPool,
+        IDecentralPool[] storage pools,
+        uint256 positionHead,
+        IDecentralPool pool
+    ) public {
+        uint256 len = positions.length;
+        for (uint256 i = positionHead; i < len; i++) {
+            if (
+                positions[i].state != NFTState.Redeemed &&
+                positionPool[i] == pool
+            ) revert PoolHasOpenPositions();
+        }
+
+        len = pools.length;
+        for (uint256 i; i < len; i++) {
+            if (pools[i] == pool) {
+                pools[i] = pools[len - 1];
+                pools.pop();
+                return;
+            }
+        }
+    }
+
+    function registerPool(
+        mapping(IDecentralPool => bool) storage isPoolRegistered,
+        mapping(address => bool) storage isRegisteredPoolToken,
+        IDecentralPool[] storage pools,
+        IDecentralPool newPool,
+        address expectedStablecoin,
+        address expectedPoolToken
+    ) public returns (address poolTokenAddr) {
+        if (address(newPool) == address(0)) revert ZeroAddress();
+        if (isPoolRegistered[newPool]) revert PoolAlreadyRegistered();
+        if (address(newPool.stablecoin()) != expectedStablecoin) {
+            revert PoolWrongStablecoin();
+        }
+        poolTokenAddr = address(newPool.poolToken());
+        if (poolTokenAddr == address(0)) revert PoolNoNFTContract();
+        if (
+            expectedPoolToken != address(0) &&
+            poolTokenAddr != expectedPoolToken
+        ) revert PoolTokenMismatch();
+
+        isPoolRegistered[newPool] = true;
+        isRegisteredPoolToken[poolTokenAddr] = true;
+        pools.push(newPool);
+    }
+
+    function validateOracle(IAggregatorV3Interface candidate) public view {
+        (, int256 answer, , uint256 updatedAt, ) = candidate.latestRoundData();
+        if (answer <= 0) revert OracleInvalidAnswer();
+        if (updatedAt == 0) revert OracleRoundIncomplete();
+        uint8 decimals = candidate.decimals();
+        if (decimals < 6 || decimals > 18) revert OracleDecimalsOutOfRange();
+    }
+
+    function oraclePrice(
+        IAggregatorV3Interface oracle
+    ) public view returns (uint256) {
+        if (address(oracle) == address(0)) revert OracleNotSet();
+        (
+            uint80 roundId,
+            int256 answer,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = oracle.latestRoundData();
+        if (answer <= 0) revert OracleInvalidAnswer();
+        if (roundId == 0 || updatedAt == 0) revert OracleRoundIncomplete();
+        if (answeredInRound < roundId) revert OracleStaleRound();
+        return (uint256(answer) * 1e18) / (10 ** oracle.decimals());
+    }
 
     /// @notice Settle pending requests in FIFO order using `available` HOLLAR
     ///         at the supplied `rate`. Locks HOLLAR into request.hollarOwed

--- a/bil-vault/src/libraries/QueueLib.sol
+++ b/bil-vault/src/libraries/QueueLib.sol
@@ -10,7 +10,6 @@ import {IAggregatorV3Interface} from "../interfaces/IAggregatorV3Interface.sol";
 ///         reference explicitly; accounting helpers return aggregate deltas
 ///         for the vault to apply at the call boundary.
 library QueueLib {
-    uint256 private constant MATURITY_SHIFT = 128;
 
     enum NFTState {
         Active,
@@ -71,33 +70,17 @@ library QueueLib {
         uint256 pendingYield
     );
 
-    /// @notice Add a packed `(maturity, positionIndex)` entry to the min-heap.
-    /// @dev Kept in the linked library so heap maintenance does not consume
-    ///      the vault's EIP-170 bytecode budget.
-    function pushMaturity(
-        uint256[] storage heap,
-        uint256 maturityTime,
-        uint256 positionIndex
-    ) public {
-        require(maturityTime <= type(uint128).max, "maturity overflow");
-        require(positionIndex <= type(uint128).max, "position overflow");
-        uint256 entry = (maturityTime << MATURITY_SHIFT) | positionIndex;
-        heap.push(entry);
-        uint256 cursor = heap.length - 1;
-        while (cursor > 0) {
-            uint256 parent = (cursor - 1) / 2;
-            if (heap[parent] <= entry) break;
-            heap[cursor] = heap[parent];
-            cursor = parent;
-        }
-        heap[cursor] = entry;
-    }
-
-    /// @notice Cap up to `maxPositions` due heap roots and return aggregate
-    ///         accounting deltas to the vault.
+    /// @notice Checkpoint up to `maxPositions` due positions starting at
+    ///         `checkpointHead`, capping each one's yield at its maturity and
+    ///         returning aggregate accounting deltas + the advanced head.
+    /// @dev Positions are appended in non-decreasing maturity order (the vault
+    ///      enforces this in `_addToBucket`), so a single monotonic
+    ///      `checkpointHead` is the earliest un-checkpointed position — no heap
+    ///      needed. Kept in the linked library so the loop does not consume the
+    ///      vault's EIP-170 bytecode budget.
     function processMaturities(
         NFTPosition[] storage positions,
-        uint256[] storage heap,
+        uint256 checkpointHead,
         uint256 maxPositions,
         uint256 timestamp,
         uint256 rateSum,
@@ -106,55 +89,39 @@ library QueueLib {
     )
         public
         returns (
-            uint256 processed,
+            uint256 newHead,
             uint256 newRateSum,
             uint256 newOffsetSum,
             uint256 pendingYieldAdded
         )
     {
+        newHead = checkpointHead;
         newRateSum = rateSum;
         newOffsetSum = offsetSum;
-        while (processed < maxPositions && heap.length > 0) {
-            uint256 entry = heap[0];
-            uint256 maturityTime = entry >> MATURITY_SHIFT;
-            if (maturityTime > timestamp) break;
-            uint256 positionIndex = uint128(entry);
-
-            _popMaturity(heap);
-            NFTPosition storage pos = positions[positionIndex];
-            uint256 rate = pos.apyWad * pos.principal;
-            uint256 capped = (rate * (maturityTime - pos.yieldStartTime)) /
-                denominator;
-            pos.pendingYield = capped;
-            pos.yieldCapped = true;
-            newRateSum -= rate;
-            newOffsetSum -= rate * pos.yieldStartTime;
-            pendingYieldAdded += capped;
-            emit PositionYieldCapped(positionIndex, maturityTime, capped);
-            unchecked { ++processed; }
+        uint256 len = positions.length;
+        uint256 processed;
+        while (processed < maxPositions && newHead < len) {
+            NFTPosition storage pos = positions[newHead];
+            // Earliest un-checkpointed position; stop once it isn't due yet.
+            if (pos.maturityTime > timestamp) break;
+            // Defensive: a position can only advance past Active after it has
+            // been checkpointed, so this is normally false at the head.
+            if (!pos.yieldCapped) {
+                uint256 rate = pos.apyWad * pos.principal;
+                uint256 capped = (rate *
+                    (pos.maturityTime - pos.yieldStartTime)) / denominator;
+                pos.pendingYield = capped;
+                pos.yieldCapped = true;
+                newRateSum -= rate;
+                newOffsetSum -= rate * pos.yieldStartTime;
+                pendingYieldAdded += capped;
+                emit PositionYieldCapped(newHead, pos.maturityTime, capped);
+            }
+            unchecked {
+                ++newHead;
+                ++processed;
+            }
         }
-    }
-
-    function _popMaturity(uint256[] storage heap) private {
-        uint256 lastIndex = heap.length - 1;
-        uint256 last = heap[lastIndex];
-        heap.pop();
-        if (lastIndex == 0) return;
-
-        uint256 cursor;
-        uint256 len = heap.length;
-        while (true) {
-            uint256 left = cursor * 2 + 1;
-            if (left >= len) break;
-            uint256 right = left + 1;
-            uint256 smallest = right < len && heap[right] < heap[left]
-                ? right
-                : left;
-            if (heap[smallest] >= last) break;
-            heap[cursor] = heap[smallest];
-            cursor = smallest;
-        }
-        heap[cursor] = last;
     }
 
     function estimatedWaitTime(

--- a/bil-vault/test/invariant/helpers/PositionReader.sol
+++ b/bil-vault/test/invariant/helpers/PositionReader.sol
@@ -13,10 +13,10 @@ contract PositionReader {
     }
 
     function principal(uint256 idx) external view returns (uint256 _principal) {
-        (, _principal,,,,,,) = vault.positions(idx);
+        (, _principal,,,,,,,) = vault.positions(idx);
     }
 
     function pendingYield(uint256 idx) external view returns (uint256 _pendingYield) {
-        (,,,,,,, _pendingYield) = vault.positions(idx);
+        (,,,,,,,, _pendingYield) = vault.positions(idx);
     }
 }

--- a/bil-vault/test/unit/MaturityCheckpoint.t.sol
+++ b/bil-vault/test/unit/MaturityCheckpoint.t.sol
@@ -8,63 +8,60 @@ import {MockDecentralPool} from "../mocks/MockDecentralPool.sol";
 import {MockPoolToken} from "../mocks/MockPoolToken.sol";
 
 contract MaturityCheckpointTest is BaseTest {
-    function test_heapOrdersOutOfOrderMaturitiesAndSyncsBounded() public {
+    /// @notice The FIFO clamp relies on positions being appended in
+    ///         non-decreasing maturity order. A deposit into a shorter-period
+    ///         pool while an older, longer-maturity position is still live must
+    ///         revert rather than silently corrupt the checkpointHead ordering.
+    function test_outOfOrderMaturityDepositReverts() public {
         pool.setMinimumInvestmentPeriodSeconds(90 days);
-        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 0, maturity 90d
+        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 0, maturity now+90d
 
+        // Switch to a 10-day pool: a new position would mature BEFORE index 0.
         MockDecentralPool pool10 = _newPool(10 days);
         _activate(pool10);
-        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 1, maturity 10d
+        vm.expectRevert(BILVault.NonMonotonicMaturity.selector);
+        _deposit(alice, TEN_THOUSAND_HOLLAR);
+    }
 
-        MockDecentralPool pool40 = _newPool(40 days);
-        _activate(pool40);
-        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 2, maturity 40d
+    /// @notice With in-order (constant-period) maturities, the unsynced view
+    ///         clamps at the earliest un-checkpointed maturity, `syncMaturities`
+    ///         advances the head one position per unit, and once fully drained
+    ///         `totalAssets` is time-invariant.
+    function test_inOrderMaturitiesClampAndBoundedSync() public {
+        // Three staggered deposits into the default 60-day pool → maturities
+        // are strictly increasing (t0+60, t5+60, t10+60), so FIFO holds.
+        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 0
+        _warpDays(5);
+        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 1
+        _warpDays(5);
+        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 2
 
-        _warpDays(100);
+        // Warp well past all three maturities without any sync.
+        _warpDays(120);
 
-        uint256 principal = 30_000e18;
-        uint256 y10 = _yield(10 days);
-        uint256 y40 = _yield(40 days);
-        uint256 y90 = _yield(90 days);
+        // Unsynced accounting is frozen at the earliest maturity: advancing
+        // time cannot inflate it (the H-01 guarantee, keeper-free).
+        uint256 clampedAssets = vault.totalAssets();
+        _warpDays(30);
+        assertEq(vault.totalAssets(), clampedAssets, "unsynced view is time-frozen");
 
-        // Before stateful sync the oracle safely clamps every live rate to
-        // the earliest root (10d).
-        assertApproxEqAbs(
-            vault.totalAssets(),
-            principal + 3 * y10,
-            3,
-            "unsynced view clamps at 10d root"
-        );
+        // Bounded sync advances one position per unit, in order.
+        assertEq(vault.checkpointHead(), 0, "nothing checkpointed yet");
+        assertEq(vault.syncMaturities(1), 1, "one processed");
+        assertEq(vault.checkpointHead(), 1, "head advanced by one");
+        assertGt(_pendingYield(0), 0, "index 0 capped");
+        assertEq(_pendingYield(1), 0, "index 1 still live");
 
-        assertEq(vault.syncMaturities(1), 1, "one root processed");
-        assertApproxEqAbs(_pendingYield(1), y10, 1, "10d position is first heap root");
-        assertEq(_pendingYield(0), 0, "90d position remains live");
-        assertEq(_pendingYield(2), 0, "40d position remains live");
-        assertApproxEqAbs(vault.totalPendingYield(), y10, 1, "10d position capped first");
-        assertApproxEqAbs(
-            vault.totalAssets(),
-            principal + y10 + 2 * y40,
-            3,
-            "remaining live rates advance only to 40d root"
-        );
-
-        assertEq(vault.syncMaturities(1), 1, "second root processed");
-        assertApproxEqAbs(_pendingYield(2), y40, 1, "40d position is second heap root");
-        assertEq(_pendingYield(0), 0, "90d position remains live after two syncs");
-        assertApproxEqAbs(vault.totalPendingYield(), y10 + y40, 2, "40d position capped second");
-        assertApproxEqAbs(
-            vault.totalAssets(),
-            principal + y10 + y40 + y90,
-            3,
-            "90d root caps final live rate"
-        );
+        // Drain the rest; NAV rises (conservative under-count corrects upward)
+        // then becomes time-invariant once fully checkpointed.
+        assertEq(vault.syncMaturities(50), 2, "remaining two processed");
+        assertEq(vault.checkpointHead(), 3, "all checkpointed");
+        assertGe(vault.totalAssets(), clampedAssets, "sync corrects upward, never down");
 
         uint256 fullyCapped = vault.totalAssets();
-        assertEq(vault.syncMaturities(1), 1, "third root processed");
-        assertApproxEqAbs(_pendingYield(0), y90, 1, "90d position is final heap root");
-        assertApproxEqAbs(vault.totalAssets(), fullyCapped, 1, "final sync is accounting-neutral");
         _warpDays(30);
         assertEq(vault.totalAssets(), fullyCapped, "time cannot move fully capped assets");
+        assertEq(vault.syncMaturities(1), 0, "nothing left to process");
     }
 
     function test_rateSensitiveDepositRevertsUntilLargeBacklogIsDrained() public {
@@ -126,7 +123,7 @@ contract MaturityCheckpointTest is BaseTest {
 
         assertEq(vault.syncMaturities(1), 1);
         assertEq(vault.totalPendingYield(), 0, "zero yield remains zero");
-        assertEq(vault.syncMaturities(1), 0, "heap entry cannot be removed twice");
+        assertEq(vault.syncMaturities(1), 0, "position cannot be checkpointed twice");
         assertEq(vault.totalPendingYield(), 0, "zero-yield sync is idempotent");
         vault.pokeDecentral(0);
         (, , , , , uint8 state) = vault.getPosition(0);

--- a/bil-vault/test/unit/MaturityCheckpoint.t.sol
+++ b/bil-vault/test/unit/MaturityCheckpoint.t.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {BaseTest} from "../helpers/BaseTest.sol";
+import {BILVault} from "../../src/BILVault.sol";
+import {IDecentralPool} from "../../src/interfaces/IDecentralPool.sol";
+import {MockDecentralPool} from "../mocks/MockDecentralPool.sol";
+import {MockPoolToken} from "../mocks/MockPoolToken.sol";
+
+contract MaturityCheckpointTest is BaseTest {
+    function test_heapOrdersOutOfOrderMaturitiesAndSyncsBounded() public {
+        pool.setMinimumInvestmentPeriodSeconds(90 days);
+        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 0, maturity 90d
+
+        MockDecentralPool pool10 = _newPool(10 days);
+        _activate(pool10);
+        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 1, maturity 10d
+
+        MockDecentralPool pool40 = _newPool(40 days);
+        _activate(pool40);
+        _deposit(alice, TEN_THOUSAND_HOLLAR); // index 2, maturity 40d
+
+        _warpDays(100);
+
+        uint256 principal = 30_000e18;
+        uint256 y10 = _yield(10 days);
+        uint256 y40 = _yield(40 days);
+        uint256 y90 = _yield(90 days);
+
+        // Before stateful sync the oracle safely clamps every live rate to
+        // the earliest root (10d).
+        assertApproxEqAbs(
+            vault.totalAssets(),
+            principal + 3 * y10,
+            3,
+            "unsynced view clamps at 10d root"
+        );
+
+        assertEq(vault.syncMaturities(1), 1, "one root processed");
+        assertApproxEqAbs(_pendingYield(1), y10, 1, "10d position is first heap root");
+        assertEq(_pendingYield(0), 0, "90d position remains live");
+        assertEq(_pendingYield(2), 0, "40d position remains live");
+        assertApproxEqAbs(vault.totalPendingYield(), y10, 1, "10d position capped first");
+        assertApproxEqAbs(
+            vault.totalAssets(),
+            principal + y10 + 2 * y40,
+            3,
+            "remaining live rates advance only to 40d root"
+        );
+
+        assertEq(vault.syncMaturities(1), 1, "second root processed");
+        assertApproxEqAbs(_pendingYield(2), y40, 1, "40d position is second heap root");
+        assertEq(_pendingYield(0), 0, "90d position remains live after two syncs");
+        assertApproxEqAbs(vault.totalPendingYield(), y10 + y40, 2, "40d position capped second");
+        assertApproxEqAbs(
+            vault.totalAssets(),
+            principal + y10 + y40 + y90,
+            3,
+            "90d root caps final live rate"
+        );
+
+        uint256 fullyCapped = vault.totalAssets();
+        assertEq(vault.syncMaturities(1), 1, "third root processed");
+        assertApproxEqAbs(_pendingYield(0), y90, 1, "90d position is final heap root");
+        assertApproxEqAbs(vault.totalAssets(), fullyCapped, 1, "final sync is accounting-neutral");
+        _warpDays(30);
+        assertEq(vault.totalAssets(), fullyCapped, "time cannot move fully capped assets");
+    }
+
+    function test_rateSensitiveDepositRevertsUntilLargeBacklogIsDrained() public {
+        // Seed idle HOLLAR first so the same backlog can exercise queue
+        // settlement as well as deposit pricing.
+        pool.setMinimumInvestmentPeriodSeconds(1 days);
+        _deposit(alice, TEN_THOUSAND_HOLLAR);
+        _warpDays(1);
+        _processPositionFull(0);
+        assertGt(vault.idleHollar(), TEN_THOUSAND_HOLLAR);
+
+        pool.setMinimumInvestmentPeriodSeconds(60 days);
+        for (uint256 i = 0; i < 50; i++) {
+            _deposit(alice, TEN_HOLLAR);
+        }
+        _deposit(bob, TEN_HOLLAR);
+        _warpDays(60);
+
+        uint256 countBefore = vault.getPositionCount();
+        assertEq(vault.maxDeposit(bob), 0, "maxDeposit reports blocked backlog");
+        assertEq(vault.maxMint(bob), 0, "maxMint reports blocked backlog");
+
+        vm.expectRevert(BILVault.MaturityBacklog.selector);
+        vm.prank(bob);
+        vault.deposit(TEN_HOLLAR, bob);
+        assertEq(vault.getPositionCount(), countBefore, "blocked deposit is atomic");
+
+        vm.expectRevert(BILVault.MaturityBacklog.selector);
+        vm.prank(bob);
+        vault.mint(TEN_HOLLAR, bob);
+
+        uint256 requestId = _requestRedeem(bob, vault.balanceOf(bob));
+        vm.expectRevert(BILVault.MaturityBacklog.selector);
+        vault.pokeQueue();
+        (, , uint256 settledBefore, uint256 owedBefore, ) = vault
+            .getRedemptionRequest(requestId);
+        assertEq(settledBefore, 0, "queue cannot lock a conservative rate");
+        assertEq(owedBefore, 0, "no HOLLAR reserved while backlog remains");
+
+        // Explicit checkpoints drain the bounded backlog before deposits can
+        // resume, keeping maxDeposit and the actual deposit behavior aligned.
+        assertEq(vault.syncMaturities(1), 1);
+        vm.expectRevert(BILVault.MaturityBacklog.selector);
+        vm.prank(charlie);
+        vault.deposit(TEN_HOLLAR, charlie);
+        assertEq(vault.syncMaturities(50), 50);
+        _deposit(charlie, TEN_HOLLAR);
+        assertEq(vault.getPositionCount(), countBefore + 1, "deposit resumes after backlog fits bound");
+
+        vault.pokeQueue();
+        (, , uint256 settledAfter, , ) = vault.getRedemptionRequest(requestId);
+        assertGt(settledAfter, 0, "queue resumes at the exact synchronized rate");
+    }
+
+    function test_zeroYieldMaturityIsCappedExactlyOnce() public {
+        pool.setAPY(0);
+        _deposit(alice, TEN_HOLLAR);
+        _warpDays(60);
+
+        assertEq(vault.syncMaturities(1), 1);
+        assertEq(vault.totalPendingYield(), 0, "zero yield remains zero");
+        assertEq(vault.syncMaturities(1), 0, "heap entry cannot be removed twice");
+        assertEq(vault.totalPendingYield(), 0, "zero-yield sync is idempotent");
+        vault.pokeDecentral(0);
+        (, , , , , uint8 state) = vault.getPosition(0);
+        assertEq(state, 3, "zero-yield position advances to principal request");
+    }
+
+    function test_syncMaturitiesRemainsAvailableWhilePaused() public {
+        _deposit(alice, TEN_HOLLAR);
+        _warpDays(60);
+        vm.prank(admin);
+        vault.pause();
+
+        assertEq(vault.syncMaturities(1), 1);
+    }
+
+    function _newPool(uint256 period) internal returns (MockDecentralPool created) {
+        MockPoolToken token = new MockPoolToken();
+        created = new MockDecentralPool(address(hollar), address(token), APY_18_PERCENT);
+        token.registerPool(address(created));
+        created.setMinimumInvestmentPeriodSeconds(period);
+        hollar.mint(address(created), 10_000_000e18);
+        vm.prank(admin);
+        vault.registerPool(IDecentralPool(address(created)));
+    }
+
+    function _activate(MockDecentralPool target) internal {
+        vm.prank(admin);
+        vault.setActiveDepositPool(IDecentralPool(address(target)));
+    }
+
+    function _yield(uint256 elapsed) internal pure returns (uint256) {
+        return (TEN_THOUSAND_HOLLAR * APY_18_PERCENT * elapsed) /
+            (365 days * 1e18);
+    }
+
+    function _pendingYield(uint256 positionIndex) internal view returns (uint256 pending) {
+        (, , , , , , , , pending) = vault.positions(positionIndex);
+    }
+}

--- a/bil-vault/test/unit/MultiPoolHeterogeneousAPY.t.sol
+++ b/bil-vault/test/unit/MultiPoolHeterogeneousAPY.t.sol
@@ -394,6 +394,7 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
 
         // T=60d: switch active to pool 3 (16%); charlie deposits
         _warpDays(30);
+        vault.syncMaturities(1); // checkpoint alice at her 60d maturity
         _registerAndActivatePool16();
         _deposit(charlie, 10_000e18);
 
@@ -412,7 +413,7 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
         // T=90d: all three have accrued for different durations
         _warpDays(30);
 
-        uint256 y0 = _expectedYield(10_000e18, APY_18_PERCENT, 90 days);
+        uint256 y0 = _expectedYield(10_000e18, APY_18_PERCENT, 60 days);
         uint256 y1 = _expectedYield(10_000e18, APY_22,         60 days);
         uint256 y2 = _expectedYield(10_000e18, APY_16,         30 days);
         uint256 expectedTotalAssets = 30_000e18 + y0 + y1 + y2;
@@ -454,13 +455,15 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
         // rates (18% for alice, 22% for bob).
         assertApproxEqRel(vault.totalAssets(), expectedAt45d, 0.001e18, "cut alone changes nothing");
 
-        // T=75d: another 30 days. Alice's 18% AND bob's 22% should keep
-        // accruing — the active pool is 16% but it has zero positions.
+        // T=75d: another 30 days. Alice is capped at her T=60 maturity while
+        // Bob's snapshotted 22% position continues accruing. The active pool
+        // is 16% but it still has zero positions.
         _warpDays(30);
+        vault.syncMaturities(1); // alice capped at T=60d; bob remains live
 
-        uint256 aliceAccrual75d = _expectedYield(10_000e18, APY_18_PERCENT, 75 days);
+        uint256 aliceAccrual60d = _expectedYield(10_000e18, APY_18_PERCENT, 60 days);
         uint256 bobAccrual45d   = _expectedYield(10_000e18, APY_22,         45 days);
-        uint256 expectedAt75d = 20_000e18 + aliceAccrual75d + bobAccrual45d;
+        uint256 expectedAt75d = 20_000e18 + aliceAccrual60d + bobAccrual45d;
         assertApproxEqRel(
             vault.totalAssets(),
             expectedAt75d,
@@ -476,10 +479,9 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
         // The blended rate continues to grow — slower than before — but
         // existing positions are unaffected.
         _warpDays(15); // T=90d
-        uint256 aliceAccrual90d  = _expectedYield(10_000e18, APY_18_PERCENT, 90 days);
         uint256 bobAccrual60d    = _expectedYield(10_000e18, APY_22,         60 days);
         uint256 charlieAccrual15d = _expectedYield(10_000e18, APY_16,        15 days);
-        uint256 expectedAt90d = 30_000e18 + aliceAccrual90d + bobAccrual60d + charlieAccrual15d;
+        uint256 expectedAt90d = 30_000e18 + aliceAccrual60d + bobAccrual60d + charlieAccrual15d;
         assertApproxEqRel(vault.totalAssets(), expectedAt90d, 0.001e18, "post-cut blend");
     }
 
@@ -502,6 +504,7 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
 
         // T=60d: switch to 16%; charlie deposits
         _warpDays(30);
+        vault.syncMaturities(1); // checkpoint alice before the new deposit
         _registerAndActivatePool16();
         _deposit(charlie, 10_000e18);
 

--- a/bil-vault/test/unit/PostMaturityYieldDrift.t.sol
+++ b/bil-vault/test/unit/PostMaturityYieldDrift.t.sol
@@ -12,11 +12,12 @@ import {BILOracle} from "../../src/BILOracle.sol";
 ///         until `executeYieldWithdrawal` revealed the actual (lower) Decentral
 ///         payout and the shortfall was socialised through `exchangeRate()`.
 ///
-///         The fix indexes active positions in a maturity min-heap. View
-///         accounting clamps the aggregate at the earliest unprocessed
-///         maturity, so the oracle is safe without a keeper transaction.
-///         Queue settlement synchronizes a bounded set of due roots, while
-///         deposits refuse to proceed until the backlog is explicitly drained.
+///         The fix tracks active positions in maturity (FIFO) order with a
+///         monotonic `checkpointHead`. View accounting clamps the aggregate at
+///         the earliest unprocessed maturity, so the oracle is safe without a
+///         keeper transaction. Queue settlement synchronizes a bounded set of
+///         due positions, while deposits refuse to proceed until the backlog
+///         is explicitly drained.
 ///
 ///         These tests assert the post-fix behaviour: (a) the rate and oracle
 ///         are stable past maturity without cleanup, (b) pendingYield equals

--- a/bil-vault/test/unit/PostMaturityYieldDrift.t.sol
+++ b/bil-vault/test/unit/PostMaturityYieldDrift.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.22;
 
 import {BaseTest} from "../helpers/BaseTest.sol";
+import {BILOracle} from "../../src/BILOracle.sol";
 
 /// @notice Audit finding H-01: pre-fix, `totalAssets()` continued accruing
 ///         virtual yield past `maturityTime` until a keeper pokes the position,
@@ -11,75 +12,62 @@ import {BaseTest} from "../helpers/BaseTest.sol";
 ///         until `executeYieldWithdrawal` revealed the actual (lower) Decentral
 ///         payout and the shortfall was socialised through `exchangeRate()`.
 ///
-///         The fix introduces a permissionless `cleanMaturedFromBucket(idx)`
-///         that anyone can call to cap a matured position's yield contribution
-///         at the maturity-bounded value, removing it from the live yield
-///         bucket and locking the capped amount into `totalPendingYield`.
-///         `pokeDecentral`'s Active→YieldWithdrawalRequested branch invokes the
-///         same internal helper, so the inflated value can never be observed
-///         once any honest party (keeper, monitor, or the redeemer themselves)
-///         caps it before the rate-sensitive step.
+///         The fix indexes active positions in a maturity min-heap. View
+///         accounting clamps the aggregate at the earliest unprocessed
+///         maturity, so the oracle is safe without a keeper transaction.
+///         Queue settlement synchronizes a bounded set of due roots, while
+///         deposits refuse to proceed until the backlog is explicitly drained.
 ///
-///         These tests assert the post-fix behaviour: (a) the rate is stable
-///         past maturity once cleaned, (b) pendingYield equals the 60-day
-///         projection rather than the post-maturity 74-day projection, and
-///         (c) an attacker who tries to lock in the inflated rate is defeated
-///         because the cleaner neutralises the bucket atomically before any
-///         settlement.
+///         These tests assert the post-fix behaviour: (a) the rate and oracle
+///         are stable past maturity without cleanup, (b) pendingYield equals
+///         the maturity-capped projection, and (c) requestRedeem + pokeQueue
+///         cannot atomically lock an inflated rate.
 contract PostMaturityYieldDriftTest is BaseTest {
-    /// @notice After `cleanMaturedFromBucket`, `exchangeRate()` is flat past
-    ///         `maturityTime` — the live yield bucket no longer accrues virtual
-    ///         yield once the position has been frozen at its maturity-capped
-    ///         amount.
-    function test_H01_exchangeRate_stable_past_maturity_after_clean() public {
+    /// @notice View accounting and the oracle cap without any cleaner tx.
+    function test_H01_viewAndOracleCapWithoutAnySync() public {
         _deposit(alice, TEN_THOUSAND_HOLLAR);
+        BILOracle priceFeed = new BILOracle(address(vault));
 
-        // Warp exactly to maturity. Snapshot the rate at the moment of
-        // maturity but BEFORE the cap is applied — this is the value the
-        // protocol must preserve from now until execute.
-        _warpDays(60);
-        vault.cleanMaturedFromBucket(0);
+        _warpDays(59);
+        uint256 rateBeforeMaturity = vault.exchangeRate();
+        _warpDays(1);
+        uint256 assetsAtMaturity = vault.totalAssets();
         uint256 rateAtMaturity = vault.exchangeRate();
+        (, int256 answerAtMaturity, , , ) = priceFeed.latestRoundData();
+        assertGt(rateAtMaturity, rateBeforeMaturity, "yield reaches maturity");
 
-        // Keeper is late. Position is still Active even though Decentral has
-        // stopped accruing on the real chain. Warp 14 more days — under the
-        // fix, the rate must NOT change because the bucket was already capped.
+        // No cleaner, keeper, poke, or other state change occurs.
         _warpDays(14);
-        uint256 rateAtPlus14 = vault.exchangeRate();
-
-        assertEq(
-            rateAtPlus14,
-            rateAtMaturity,
-            "rate must NOT drift past maturity once the position has been capped"
-        );
+        assertEq(vault.totalAssets(), assetsAtMaturity, "assets capped without sync");
+        assertEq(vault.exchangeRate(), rateAtMaturity, "rate capped without sync");
+        (, int256 answerAfterDelay, , , ) = priceFeed.latestRoundData();
+        assertEq(answerAfterDelay, answerAtMaturity, "oracle capped without sync");
+        assertEq(vault.totalPendingYield(), 0, "no hidden state cleanup occurred");
     }
 
-    /// @notice `cleanMaturedFromBucket` is idempotent: a second call (or any
-    ///         later call) is a no-op and the rate stays flat.
-    function test_H01_cleanMaturedFromBucket_idempotent() public {
+    /// @notice Maturity synchronization is idempotent.
+    function test_H01_syncMaturities_idempotent() public {
         _deposit(alice, TEN_THOUSAND_HOLLAR);
 
         _warpDays(60);
-        vault.cleanMaturedFromBucket(0);
+        assertEq(vault.syncMaturities(1), 1);
         uint256 rateAfterFirstClean = vault.exchangeRate();
         uint256 pendingAfterFirstClean = vault.totalPendingYield();
 
         // Second call same block — no-op.
-        vault.cleanMaturedFromBucket(0);
+        assertEq(vault.syncMaturities(1), 0);
         assertEq(vault.exchangeRate(), rateAfterFirstClean, "rate unchanged after redundant clean");
         assertEq(vault.totalPendingYield(), pendingAfterFirstClean, "pending unchanged after redundant clean");
 
         // Warp + clean again — still a no-op because pendingYield != 0.
         _warpDays(7);
-        vault.cleanMaturedFromBucket(0);
+        assertEq(vault.syncMaturities(1), 0);
         assertEq(vault.exchangeRate(), rateAfterFirstClean, "rate flat across redundant late clean");
         assertEq(vault.totalPendingYield(), pendingAfterFirstClean, "pending flat across redundant late clean");
     }
 
-    /// @notice `cleanMaturedFromBucket` is a no-op for pre-maturity positions
-    ///         — it never freezes a position whose yield is still legitimately
-    ///         accruing.
-    function test_H01_cleanMaturedFromBucket_pre_maturity_is_noop() public {
+    /// @notice Synchronization is a no-op before the earliest maturity.
+    function test_H01_syncMaturities_pre_maturity_is_noop() public {
         _deposit(alice, TEN_THOUSAND_HOLLAR);
 
         uint256 rateBefore = vault.exchangeRate();
@@ -87,10 +75,10 @@ contract PostMaturityYieldDriftTest is BaseTest {
 
         // Still well before maturity. Clean is a no-op.
         _warpDays(30);
-        vault.cleanMaturedFromBucket(0);
+        assertEq(vault.syncMaturities(1), 0);
 
         // The rate should reflect 30 days of legitimate accrual — unchanged
-        // by the clean call. pendingYield should also be unchanged (0).
+        // by the sync call. pendingYield should also be unchanged (0).
         assertGt(vault.exchangeRate(), rateBefore, "30d legitimate accrual visible");
         assertEq(vault.totalPendingYield(), pendingBefore, "no pending yield locked pre-maturity");
 
@@ -110,9 +98,9 @@ contract PostMaturityYieldDriftTest is BaseTest {
         // 14 days past maturity, no poke.
         _warpDays(60 + 14);
 
-        // The mock pool also caps at maturityTime under the fix (no need to
-        // configure a yieldDelta — Decentral pays exactly 60d). We compute
-        // both reference values to make the assertion explicit.
+        // The mock accrues until the late request at day 74, so below we apply
+        // a negative payout adjustment to model Decentral's 60-day cap. We
+        // compute both reference values to make the assertion explicit.
         uint256 principal = TEN_THOUSAND_HOLLAR;
         uint256 yieldFor60d = (principal * APY_18_PERCENT * 60 days) /
             (365 days * 1e18);
@@ -142,9 +130,9 @@ contract PostMaturityYieldDriftTest is BaseTest {
         // Decentral approves and the vault executes. Configure the mock to pay
         // exactly the 60-day amount (no overpay, no shortfall) — this is what
         // a maturity-respecting Decentral would do.
-        int256 yieldOverpay = int256(yieldFor60d) -
+        int256 yieldAdjustment = int256(yieldFor60d) -
             int256((principal * APY_18_PERCENT * 74 days) / (365 days * 1e18));
-        pool.setYieldDelta(_tokenIdOf(0), yieldOverpay);
+        pool.setYieldDelta(_tokenIdOf(0), yieldAdjustment);
 
         uint256 taBeforeExecute = vault.totalAssets();
         pool.approveYieldWithdrawal(_tokenIdOf(0));
@@ -162,66 +150,39 @@ contract PostMaturityYieldDriftTest is BaseTest {
         );
     }
 
-    /// @notice Attack: when a matured-but-not-poked position SHOULD inflate the
-    ///         rate, the attacker plans to requestRedeem + pokeQueue to lock
-    ///         in the inflated rate. Under the fix, anyone (including the
-    ///         attacker's would-be victim, a monitor bot, or the protocol
-    ///         keeper) can call `cleanMaturedFromBucket` atomically before
-    ///         settlement to neutralise the inflation — Bob ends up locking
-    ///         at the honest post-maturity rate and extracts ZERO HOLLAR over
-    ///         his fair share.
+    /// @notice Attack: a matured-but-unprocessed position is left untouched,
+    ///         then requestRedeem + pokeQueue are called back-to-back. Queue
+    ///         settlement must synchronize before it rate-locks the request.
     ///
     ///         Setup uses three positions:
     ///         - Position 0 (Alice): fully redeemed early, leaving idle HOLLAR
     ///         - Position 1 (Bob, the attacker): matured but unpoked
     ///         - Position 2 (Charlie): a long-term holder
-    function test_H01_attack_neutralised_by_clean() public {
+    function test_H01_atomicRateLockAttackFailsWithoutCleaner() public {
         _deposit(alice, TEN_THOUSAND_HOLLAR);
+
+        // Alice matures first; Bob and Charlie start two weeks later.
+        _warpDays(14);
         _deposit(bob, TEN_THOUSAND_HOLLAR);
         _deposit(charlie, TEN_THOUSAND_HOLLAR);
 
-        // 60 days: all three mature.
-        _warpDays(60);
-
-        // Alice's position is processed promptly. Her ~10300 HOLLAR (principal
-        // + yield) sits in idleHollar.
+        // At T+60d Alice returns idle liquidity while the other positions are
+        // still live. _processPositionFull advances another 48h to T+62d.
+        _warpDays(46);
         _processPositionFull(0);
         uint256 idle = vault.idleHollar();
         assertGt(idle, TEN_THOUSAND_HOLLAR, "idleHollar from Alice's full redeem");
 
-        // Keeper sleeps. Without the fix, Bob's position would inflate the
-        // rate for 14 more days. Under the fix, anyone can call
-        // `cleanMaturedFromBucket` to freeze the matured positions at their
-        // maturity-capped value — the rate becomes drift-immune.
-        _warpDays(14);
-
-        // ─── Defensive sweep: any honest party caps the matured positions ───
-        // (Could be the keeper, a monitor bot, Bob's own counterparty, or
-        // even Bob himself before submitting his redemption — the call is
-        // permissionless and the result is the same.)
-        vault.cleanMaturedFromBucket(1);
-        vault.cleanMaturedFromBucket(2);
-
+        // Snapshot Bob's honest rate at T+74d, then leave his matured position
+        // completely untouched for another two weeks.
+        _warpDays(12);
         uint256 honestRate = vault.exchangeRate();
+        _warpDays(14);
+        assertEq(vault.exchangeRate(), honestRate, "stale oracle remains capped");
 
-        // Configure the mock to cap at 60d for Bob's position (what real
-        // Decentral would do) so we can verify zero shortfall later.
-        {
-            uint256 principal = TEN_THOUSAND_HOLLAR;
-            uint256 y60 = (principal * APY_18_PERCENT * 60 days) /
-                (365 days * 1e18);
-            uint256 y74 = (principal * APY_18_PERCENT * 74 days) /
-                (365 days * 1e18);
-            pool.setYieldDelta(_tokenIdOf(1), int256(y60) - int256(y74));
-        }
-
-        // Attack step 1: Bob requests redemption of all his shares.
+        // Bob atomically requests and settles without giving a cleaner a turn.
         uint256 bobShares = vault.balanceOf(bob);
         uint256 reqId = _requestRedeem(bob, bobShares);
-
-        // Attack step 2: pokeQueue settles his request against idleHollar at
-        // what would be the inflated rate — but the bucket has already been
-        // capped, so the lock-in rate is honest.
         vault.pokeQueue();
 
         (, uint256 bilAmount, uint256 bilSettled, uint256 hollarOwed, ) = vault
@@ -230,41 +191,8 @@ contract PostMaturityYieldDriftTest is BaseTest {
         assertGt(bilSettled, 0, "at least partial settle from idleHollar");
 
         uint256 hollarOwedPerBil = (hollarOwed * 1e18) / bilSettled;
-        assertApproxEqRel(
-            hollarOwedPerBil,
-            honestRate,
-            0.001e18,
-            "Bob locked in at the honest (capped) rate, not an inflated one"
-        );
-
-        // Bob's position lifecycle plays out. With the fix, pokeDecentral
-        // re-uses the already-capped pendingYield (no recompute) and
-        // executeYieldWithdrawal pays the matching 60d amount.
-        vault.pokeDecentral(1); // Active -> YieldWithdrawalRequested (no recompute, uses pendingYield)
-        pool.approveYieldWithdrawal(_tokenIdOf(1));
-        vault.pokeDecentral(1); // YieldWithdrawalRequested -> YieldClaimed (no shortfall)
-
-        uint256 postExecuteRate = vault.exchangeRate();
-
-        // Under the fix, the post-execute rate equals Bob's lock-in rate
-        // (within rounding) — no extraction, the attack is defeated.
-        assertApproxEqRel(
-            postExecuteRate,
-            hollarOwedPerBil,
-            0.001e18,
-            "post-execute rate matches Bob's lock-in - no over-extraction"
-        );
-
-        // Quantify any residual extraction. Under the fix the per-BIL gap is
-        // sub-wei after rounding; the cumulative over-extraction must be zero
-        // (or, at most, a few wei of rounding noise — not the ~14d*APY*P
-        // shortfall the pre-fix code allowed).
-        uint256 perBilOverExtract = postExecuteRate >= hollarOwedPerBil
-            ? 0
-            : hollarOwedPerBil - postExecuteRate;
-        uint256 totalOver = (perBilOverExtract * bilSettled) / 1e18;
-        emit log_named_uint("Bob stole HOLLAR (wei)", totalOver);
-        assertEq(totalOver, 0, "extraction is zero - fix neutralises the attack");
+        assertLe(hollarOwedPerBil, honestRate, "cannot lock phantom yield");
+        assertApproxEqAbs(hollarOwedPerBil, honestRate, 2, "locks honest rate");
     }
 
     function _tokenIdOf(uint256 positionIndex) internal view returns (uint256) {

--- a/bil-vault/test/unit/ProcessPosition.t.sol
+++ b/bil-vault/test/unit/ProcessPosition.t.sol
@@ -503,6 +503,7 @@ contract ProcessPositionTest is BaseTest {
 
         // Mature all positions simultaneously.
         _warpDays(61);
+        vault.syncMaturities(n);
 
         // Redeem positions [n-1, n-2, ..., 1], leaving 0 Active so that
         // _advancePositionHead won't advance during the loop.

--- a/bil-vault/test/unit/YieldRequestWindow.t.sol
+++ b/bil-vault/test/unit/YieldRequestWindow.t.sol
@@ -14,7 +14,7 @@ import {BILVault} from "../../src/BILVault.sol";
 contract YieldRequestWindowTest is BaseTest {
     /// @dev Per-position pendingYield via the public struct getter (last tuple element).
     function _pendingYield(uint256 idx) internal view returns (uint256 py) {
-        (,,,,,,, py) = vault.positions(idx);
+        (,,,,,,,, py) = vault.positions(idx);
     }
 
     /// @dev Bring position 0 to YieldWithdrawalRequested.


### PR DESCRIPTION
Alternative to #47 — same H-01 fix, minus the min-heap.

## What changed vs #47
#47 tracks active-position maturities in a packed `(maturity,index)` **min-heap**. This branch replaces it with a single monotonic **`checkpointHead`** index. Everything else #47 does (the passive `totalAssets` clamp, `syncMaturities`, backlog-gating of deposit/mint/rate-lock, the QueueLib relocations for EIP-170, the keeper drain, the tests) is kept.

The index works because BIL positions are appended in **non-decreasing maturity order** (single pool, constant investment period). That invariant is now enforced by `NonMonotonicMaturity` in `_addToBucket`, so switching to a shorter-period pool while older positions are live fails loudly instead of silently mis-clamping.

## Why
Same passive-safety guarantee (NAV can never show phantom post-maturity yield without a keeper → H-01 rate-lock attack is dead), but drops ~80 lines of heap machinery (`pushMaturity` / `_popMaturity` / heapify / packed entries) — the trickiest, most bug-prone part of #47 — for an O(1) index advance.

## Trade-off
The heap handled **out-of-order** maturities (heterogeneous multi-pool). This branch does not — it requires FIFO maturity order and reverts otherwise. That's the correct constraint for the single-Decentral-pool launch; heterogeneous multi-pool would need the heap back (or a later upgrade).

## Verified
- `forge test --no-match-path 'test/integration/**'`: **372 passed, 0 failed**
- BILVault runtime **24,322 bytes** (254 under EIP-170)
- Storage layout unchanged vs #47 (`_maturityHeap` 1 slot → `checkpointHead` 1 slot; `__gap` still 47)

Pick this **or** #47, not both — they solve the same finding.