### PR TITLE
bil-vault: queue fills — strict-FIFO early settlement with partial fills

### DIFF
--- a/bil-vault/QUEUE-FILLS-SPEC.md
+++ b/bil-vault/QUEUE-FILLS-SPEC.md
@@ -5,6 +5,46 @@ Variant B of `QUEUE-FILLS-PLAN.md` — strict-FIFO early settlement with
 partial fills. The plan holds the rationale; this holds what to type.
 All line references are to current `feat/bil`.
 
+## As built (feat/queue-fills) — deltas from this spec
+
+Implemented 2026-07-21. The core mechanics (walk semantics, pricing,
+partial fills, invariants) landed exactly as specced; the *packaging*
+changed because the vault had only **313 bytes** of EIP-170 headroom and
+the spec's surface cost ~2.4KB. Deviations:
+
+- **Everything heavy lives in QueueLib**: `setAsk` (listing validation +
+  events), `cancel` (the whole `cancelRedeem` body except the hDCL
+  refund), and `executeFill` (walk + payment legs + all events,
+  including the `QueueFilled` batch summary). Delegatecall preserves
+  `msg.sender`, so auth checks in the library are sound, and lib events
+  surface from the vault address as usual.
+- **`clearFillAsk` is gone** — `setFillAsk(id, QueueLib.CLEAR_ASK)`
+  (`type(uint32).max`) delists, idempotently.
+- **`fillQueue(maxHollarIn, minAskBps)` has no `minBilOut`** —
+  `minAskBps` already bounds the worst per-share price and
+  `maxHollarIn` bounds total spend; NAV drift between quote and tx is
+  noise. `NothingFilled` reverts from the library.
+- **No on-chain `previewFillQueue` / `getFillAsk`** — the ask is exposed
+  as a sixth output on `getRedemptionRequest` (`askPlusOne`, 0 = not
+  listed); quoting is off-chain (walk `getRedemptionRequest` over
+  `queueHead..queueTail` — or a periphery lens contract later, zero
+  vault bytecode either way).
+- **Paid-for headroom** (existing surface offloaded/deduped):
+  `cancelRedeem` body → lib; `redemptionQueue` and `positions`
+  internalized (their raw auto-getters were redundant with
+  `getRedemptionRequest`/`getPosition` — which gained the missing
+  fields: `askPlusOne`, resp. `yieldCapped`/`pendingYield`/
+  `yieldStartTime`, appended so old static-decode consumers keep
+  working); dropped `getTotalQueuedBil`/`getIdleHollar`/
+  `getRedemptionQueueLength`/`getQueueHead` (the public vars are the
+  getters; keeper migrated to `queueTail`).
+- Result: vault 24,443 bytes (**133 spare**), QueueLib 8,967 (libraries
+  are exempt from meaningful pressure). Feature's net vault cost after
+  offsets: ~180 bytes.
+- Tests: `test/unit/QueueFills.t.sol` (18 cases covering the §8 matrix
+  incl. accounting-neutrality snapshots) + `setFillAsk`/`fillQueue`
+  actions in the invariant fuzz suite. 391 tests green.
+
 ## 0. Summary of the mechanism
 
 Exiters opt in by setting an **ask** (discount in bps) on their queued

--- a/bil-vault/keeper/src/keeper.ts
+++ b/bil-vault/keeper/src/keeper.ts
@@ -121,7 +121,9 @@ const VAULT_ABI = [
   },
   // ─── ERC-7540 redemption queue ───────────────────────────────────────
   {
-    name: 'getRedemptionQueueLength',
+    // renamed: the explicit getter was dropped for EIP-170 budget; the
+    // public storage var's auto-getter is the canonical read now.
+    name: 'queueTail',
     type: 'function',
     stateMutability: 'view',
     inputs: [],
@@ -276,7 +278,7 @@ export class BILKeeper {
   /// Receiver is forced to the controller — `CLAIM_OPERATOR_ROLE` only
   /// authorizes timing, not redirection.
   private async autoClaimSettled(): Promise<void> {
-    const queueLen = (await this.readContract('getRedemptionQueueLength')) as bigint;
+    const queueLen = (await this.readContract('queueTail')) as bigint;
     if (queueLen === 0n) return;
 
     // Sum settled shares per controller across all live requests.

--- a/bil-vault/src/BILVault.sol
+++ b/bil-vault/src/BILVault.sol
@@ -65,6 +65,10 @@ contract BILVault is
     ///      drained every overdue root.
     uint256 internal constant MAX_MATURITY_SYNC = 50;
 
+    /// @dev Ceiling on a queue-fill ask: 20%. A fat-finger guard, not an
+    ///      economic bound — the market clears far below it.
+    uint32 internal constant MAX_FILL_ASK_BPS = 2_000;
+
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
     /// @notice Fast-path role for the Hydration technical committee.
@@ -164,7 +168,9 @@ contract BILVault is
     // ═══════════════════════════════════════════════════════════════════════
 
     /// @notice All NFT positions, ordered by deposit time
-    QueueLib.NFTPosition[] public positions;
+    /// @dev Internal — read via `getPosition` (the 9-field auto-getter
+    ///      didn't fit the EIP-170 budget once queue fills landed).
+    QueueLib.NFTPosition[] internal positions;
     /// @notice Index of the first non-redeemed position
     uint256 public positionHead;
 
@@ -173,7 +179,9 @@ contract BILVault is
     // ═══════════════════════════════════════════════════════════════════════
 
     /// @notice FIFO queue of pending redemptions
-    mapping(uint256 => QueueLib.Request) public redemptionQueue;
+    /// @dev Internal — read via `getRedemptionRequest` (the auto-getter
+    ///      didn't fit the EIP-170 budget once queue fills landed).
+    mapping(uint256 => QueueLib.Request) internal redemptionQueue;
     /// @notice Index of the first active (unfulfilled) request
     uint256 public queueHead;
     /// @notice Index of the next request to be created
@@ -246,7 +254,6 @@ contract BILVault is
         address indexed user,
         uint256 bilAmount
     );
-    event RedemptionCancelled(uint256 indexed requestId, uint256 bilReturned);
     // RedemptionFulfilled / RedemptionPartiallyFulfilled moved to QueueLib.
     // They're emitted under DELEGATECALL so logs still appear at the vault's
     // address and tests' expectEmit matches by topic+data regardless.
@@ -293,6 +300,12 @@ contract BILVault is
         uint256 maturityTime,
         uint256 pendingYield
     );
+    // FillAskSet / FillAskCleared / RequestFilled / RequestPartiallyFilled /
+    // QueueFilled are declared and emitted in QueueLib (bytecode budget —
+    // see EIP-170 note on the library). They surface from the vault address
+    // as usual.
+    /// @notice Fills kill switch toggled.
+    event FillsEnabledSet(bool enabled);
 
     // ═══════════════════════════════════════════════════════════════════════
     //                            ERRORS
@@ -351,6 +364,9 @@ contract BILVault is
     );
     error BpsAboveMax();
     error MaturityBacklog();
+    // AskTooHigh / NothingPending and the listing auth errors live in
+    // QueueLib next to setAsk/clearAsk.
+    error FillsDisabled();
 
     // ═══════════════════════════════════════════════════════════════════════
     //                         INITIALIZER
@@ -594,39 +610,102 @@ contract BILVault is
     ///         request was fully unsettled at cancel time, it's deleted from
     ///         the queue entirely.
     function cancelRedeem(uint256 requestId) external nonReentrant {
-        if (requestId >= queueTail) revert InvalidRequestId();
-        QueueLib.Request storage request = redemptionQueue[requestId];
-        address controller = request.user;
-        if (controller == address(0)) revert RequestNotActive();
-        if (msg.sender != controller && !isOperator[controller][msg.sender])
-            revert NotRequestOwner();
-
-        uint256 unsettled = request.bilAmount - request.bilSettled;
+        // Auth, ask-clear, entry shrink/delete, head sweep and events live
+        // in QueueLib (bytecode budget); the vault applies the accounting
+        // delta and refunds the escrowed hDCL. Refund goes to the
+        // CONTROLLER — when an operator cancels, funds do not follow the
+        // operator.
+        (uint256 newHead, address controller, uint256 unsettled) = QueueLib.cancel(
+            redemptionQueue,
+            fillAskPlusOne,
+            isOperator,
+            requestId,
+            queueHead,
+            queueTail
+        );
+        queueHead = newHead;
         if (unsettled > 0) {
             totalQueuedBil -= unsettled;
-            request.bilAmount = request.bilSettled; // shrink to settled portion
-            // Refund the unsettled hDCL to the controller. When an operator
-            // cancels, the funds still go to the controller, not the operator.
             _transfer(address(this), controller, unsettled);
-            emit RedemptionCancelled(requestId, unsettled);
         }
+    }
 
-        // If nothing was settled, the request has nothing left — delete it
-        // and try to compact the queue head.
-        if (request.bilSettled == 0) {
-            delete redemptionQueue[requestId];
+    // ═══════════════════════════════════════════════════════════════════════
+    //                     QUEUE FILLS (early settlement)
+    // ═══════════════════════════════════════════════════════════════════════
 
-            // Head sweep — same logic as before, bounded by MAX_QUEUE_ITERATIONS
-            // so the canceller's gas stays bounded even with many head holes.
-            if (requestId == queueHead) {
-                queueHead = QueueLib.advanceQueueHead(
-                    redemptionQueue,
-                    queueHead,
-                    queueTail,
-                    MAX_QUEUE_ITERATIONS
-                );
-            }
-        }
+    /// @notice List (or re-price) the pending portion of a redemption
+    ///         request for third-party filling at `askBps` below NAV.
+    /// @dev    Controller or approved ERC-7540 operator (same auth shape as
+    ///         `cancelRedeem`; fill proceeds always go to the controller, so
+    ///         an operator can list but never redirect). Listing is allowed
+    ///         while fills are disabled — the flag gates only `fillQueue`,
+    ///         so arming fills later doesn't require everyone to re-list.
+    ///         `askBps == QueueLib.CLEAR_ASK` (type(uint32).max) delists,
+    ///         idempotently. Validation + events live in QueueLib
+    ///         (bytecode budget).
+    function setFillAsk(uint256 requestId, uint32 askBps) external {
+        QueueLib.setAsk(
+            redemptionQueue,
+            fillAskPlusOne,
+            isOperator,
+            requestId,
+            queueTail,
+            askBps,
+            MAX_FILL_ASK_BPS
+        );
+    }
+
+    /// @notice Buy queued BIL strictly head-first from listed exiters.
+    ///         Pays each listed entry's controller `pending × rate × (1 −
+    ///         ask)` from msg.sender and releases the escrowed hDCL to
+    ///         msg.sender. The last entry is filled partially when the
+    ///         budget runs short. Never touches vault accounting: rate,
+    ///         totalAssets, idleHollar and totalReservedHollar are all
+    ///         invariant across a fill.
+    /// @param maxHollarIn  Budget; pulled from msg.sender per filled entry.
+    /// @param minAskBps    Price filter: fill only entries asking a discount
+    ///                     ≥ this. Cheaper-discount entries are skipped,
+    ///                     never stopped at. 0 = fill every listed entry.
+    ///                     Also the slippage bound: worst per-share price is
+    ///                     rate × (1 − minAskBps), total spend is capped by
+    ///                     maxHollarIn, so no separate minOut is needed
+    ///                     (NAV drifts ~0.05%/day — quote-to-tx movement is
+    ///                     noise).
+    function fillQueue(
+        uint256 maxHollarIn,
+        uint32 minAskBps
+    ) external nonReentrant whenNotPaused returns (uint256 hollarSpent, uint256 bilReceived) {
+        if (!fillsEnabled) revert FillsDisabled();
+        _syncBeforeRateSensitiveAction();
+
+        // The library mutates queue state, then pays each controller from
+        // msg.sender (CEI within the call — HOLLAR has no transfer hooks,
+        // and this function is nonReentrant regardless).
+        (uint256 newHead, uint256 spent, uint256 filled, ) = QueueLib.executeFill(
+            redemptionQueue,
+            fillAskPlusOne,
+            hollar,
+            queueHead,
+            queueTail,
+            maxHollarIn,
+            minAskBps,
+            exchangeRate()
+        );
+
+        queueHead = newHead;
+        totalQueuedBil -= filled;
+        _transfer(address(this), msg.sender, filled); // escrow → filler
+        return (spent, filled);
+    }
+
+    /// @notice Arm or kill queue fills. Guardian may kill; only the admin
+    ///         may arm (mirrors the pause conventions: emergency response
+    ///         is fast-path, re-enabling risk surface is not).
+    function setFillsEnabled(bool enabled) external onlyAdminOrGuardian {
+        if (enabled) _checkRole(ADMIN_ROLE); // guardian may kill, only admin arms
+        fillsEnabled = enabled;
+        emit FillsEnabledSet(enabled);
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -1190,11 +1269,22 @@ contract BILVault is
             uint256 bilAmount,
             uint256 bilSettled,
             uint256 hollarOwed,
-            bool active
+            bool active,
+            uint32 askPlusOne
         )
     {
+        // askPlusOne appended for the fills feature (0 = not listed, else
+        // askBps + 1). Old 5-output ABI consumers keep decoding fine —
+        // static fields, extra tail word ignored.
         QueueLib.Request storage r = redemptionQueue[requestId];
-        return (r.user, r.bilAmount, r.bilSettled, r.hollarOwed, r.user != address(0));
+        return (
+            r.user,
+            r.bilAmount,
+            r.bilSettled,
+            r.hollarOwed,
+            r.user != address(0),
+            fillAskPlusOne[requestId]
+        );
     }
 
     /// @notice Get NFT position details
@@ -1209,9 +1299,16 @@ contract BILVault is
             uint256 apyWad,
             uint256 depositTime,
             uint256 maturityTime,
-            uint8 state
+            uint8 state,
+            bool yieldCapped,
+            uint256 pendingYield,
+            uint256 yieldStartTime
         )
     {
+        // Three fields appended (replacing the removed `positions` raw
+        // auto-getter). Callers built against the old 6-field ABI keep
+        // decoding fine — every field is static, extra tail words are
+        // ignored.
         QueueLib.NFTPosition storage pos = positions[positionIndex];
         return (
             pos.tokenId,
@@ -1219,7 +1316,10 @@ contract BILVault is
             pos.apyWad,
             pos.depositTime,
             pos.maturityTime,
-            uint8(pos.state)
+            uint8(pos.state),
+            pos.yieldCapped,
+            pos.pendingYield,
+            pos.yieldStartTime
         );
     }
 
@@ -1233,34 +1333,14 @@ contract BILVault is
         return positionHead;
     }
 
-    /// @notice Total BIL currently queued for redemption
-    function getTotalQueuedBil() external view returns (uint256) {
-        return totalQueuedBil;
-    }
-
-    /// @notice HOLLAR available for queue fulfillment or reinvestment
-    function getIdleHollar() external view returns (uint256) {
-        return idleHollar;
-    }
-
     /// @notice Current fixed APY from the Decentral pool
     function getAPYWad() public view returns (uint256) {
         return activeDepositPool.fixedAPYWad();
     }
 
-    /// @notice Total number of redemption requests ever created
-    function getRedemptionQueueLength() external view returns (uint256) {
-        return queueTail;
-    }
-
     /// @notice Number of pending (unprocessed) queue entries
     function getRedemptionQueuePending() external view returns (uint256) {
         return queueTail - queueHead;
-    }
-
-    /// @notice Queue head index
-    function getQueueHead() external view returns (uint256) {
-        return queueHead;
     }
 
     /// @notice Get BIL/HOLLAR price from the oracle, returned in 18 decimals.
@@ -1636,9 +1716,22 @@ contract BILVault is
     uint256[] private _maturityHeap;
 
     // ═══════════════════════════════════════════════════════════════════════
+    //                       QUEUE FILLS (upgrade slot block)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    /// @notice requestId → ask discount in bps, stored offset by +1
+    ///         (0 = not listed; UIs unpack v-1). Cleared on delist, cancel,
+    ///         and full drain of the pending portion. Internal — read via
+    ///         getRedemptionRequest (EIP-170 budget).
+    mapping(uint256 => uint32) internal fillAskPlusOne;
+    /// @notice Global fills switch. Ships false; armed by admin once
+    ///         keeper/indexer/UI support is live. Guardian can kill.
+    bool public fillsEnabled;
+
+    // ═══════════════════════════════════════════════════════════════════════
     //                         STORAGE GAP
     // ═══════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades.
-    uint256[47] private __gap;
+    uint256[45] private __gap;
 }

--- a/bil-vault/src/libraries/QueueLib.sol
+++ b/bil-vault/src/libraries/QueueLib.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.22;
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import {IDecentralPool} from "../interfaces/IDecentralPool.sol";
 import {IAggregatorV3Interface} from "../interfaces/IAggregatorV3Interface.sol";
 
@@ -10,7 +13,18 @@ import {IAggregatorV3Interface} from "../interfaces/IAggregatorV3Interface.sol";
 ///         reference explicitly; accounting helpers return aggregate deltas
 ///         for the vault to apply at the call boundary.
 library QueueLib {
+    using SafeERC20 for IERC20;
+
     uint256 private constant MATURITY_SHIFT = 128;
+    uint256 private constant BPS = 10_000;
+    uint256 private constant WAD_ = 1e18;
+    /// @dev Same work/skip budgets as the vault's pokeQueue constants —
+    ///      owned here for the fill path so the vault doesn't spend
+    ///      bytecode marshaling them (EIP-170).
+    uint256 private constant MAX_FILL_ITERATIONS = 50;
+    uint256 private constant MAX_FILL_SKIPS = 500;
+    /// @notice Sentinel askBps for setAsk meaning "delist".
+    uint32 public constant CLEAR_ASK = type(uint32).max;
 
     enum NFTState {
         Active,
@@ -40,7 +54,22 @@ library QueueLib {
         uint256 hollarOwed;    // HOLLAR reserved for the settled portion
     }
 
+    /// @dev One payment leg of a fill walk: HOLLAR the filler owes a
+    ///      controller whose pending shares were bought. Internal to
+    ///      `executeFill` — collected during the walk, paid after all
+    ///      state writes (CEI inside the library call).
+    struct FillPay {
+        address controller;
+        uint256 amount;
+    }
+
     error InsufficientClaimable();
+    error NothingFilled();
+    error AskTooHigh();
+    error NothingPending();
+    error NotRequestOwner();
+    error RequestNotActive();
+    error InvalidRequestId();
     error PoolHasOpenPositions();
     error ZeroAddress();
     error PoolAlreadyRegistered();
@@ -69,6 +98,37 @@ library QueueLib {
         uint256 indexed positionIndex,
         uint256 maturityTime,
         uint256 pendingYield
+    );
+    /// @notice A controller listed (or re-priced) their request's pending
+    ///         portion for third-party filling.
+    event FillAskSet(uint256 indexed requestId, address indexed controller, uint32 askBps);
+    /// @notice A listing was removed — explicitly, on cancel, or on full drain.
+    event FillAskCleared(uint256 indexed requestId);
+    /// @notice A request's unsettled portion was cancelled and refunded.
+    event RedemptionCancelled(uint256 indexed requestId, uint256 bilReturned);
+    /// @notice A fill bought a request's entire pending portion.
+    event RequestFilled(
+        uint256 indexed requestId,
+        address indexed controller,
+        uint256 hollarPaid,
+        uint256 bilFilled
+    );
+    /// @notice A fill bought part of a request's pending portion (the
+    ///         filler's budget ran out); the remainder stays queued and
+    ///         listed at the same ask.
+    event RequestPartiallyFilled(
+        uint256 indexed requestId,
+        address indexed controller,
+        uint256 hollarPaid,
+        uint256 bilFilled
+    );
+    /// @notice Batch summary of one fillQueue call. Per-entry detail is in
+    ///         RequestFilled / RequestPartiallyFilled.
+    event QueueFilled(
+        address indexed filler,
+        uint256 hollarSpent,
+        uint256 bilReceived,
+        uint256 entriesTouched
     );
 
     /// @notice Add a packed `(maturity, positionIndex)` entry to the min-heap.
@@ -447,6 +507,230 @@ library QueueLib {
                 // Don't increment cursor — break out via available == 0 check.
             }
         }
+    }
+
+    /// @notice List, re-price, or delist a request's pending portion for
+    ///         third-party filling. `askBps == CLEAR_ASK` delists
+    ///         (idempotent). Auth: controller or approved ERC-7540 operator
+    ///         (delegatecall preserves msg.sender). Fill proceeds always go
+    ///         to the controller, so an operator can list but never
+    ///         redirect.
+    function setAsk(
+        mapping(uint256 => Request) storage queue,
+        mapping(uint256 => uint32) storage askPlusOne,
+        mapping(address => mapping(address => bool)) storage isOperator,
+        uint256 requestId,
+        uint256 queueTail_,
+        uint32 askBps,
+        uint32 maxAskBps
+    ) public {
+        if (requestId >= queueTail_) revert InvalidRequestId();
+        Request storage r = queue[requestId];
+        address controller = r.user;
+        if (controller == address(0)) revert RequestNotActive();
+        if (msg.sender != controller && !isOperator[controller][msg.sender])
+            revert NotRequestOwner();
+        if (askBps == CLEAR_ASK) {
+            if (askPlusOne[requestId] == 0) return;
+            delete askPlusOne[requestId];
+            emit FillAskCleared(requestId);
+            return;
+        }
+        if (askBps > maxAskBps) revert AskTooHigh();
+        if (r.bilAmount == r.bilSettled) revert NothingPending();
+        askPlusOne[requestId] = askBps + 1;
+        emit FillAskSet(requestId, controller, askBps);
+    }
+
+    /// @notice Cancel the still-unsettled portion of a redemption request.
+    ///         Auth: controller or approved ERC-7540 operator. Clears any
+    ///         fill listing, shrinks the entry to its settled portion (or
+    ///         deletes it entirely when nothing is settled) and sweeps the
+    ///         queue head. The vault applies `unsettled` to totalQueuedBil
+    ///         and refunds the escrowed hDCL to `controller`.
+    function cancel(
+        mapping(uint256 => Request) storage queue,
+        mapping(uint256 => uint32) storage askPlusOne,
+        mapping(address => mapping(address => bool)) storage isOperator,
+        uint256 requestId,
+        uint256 queueHead_,
+        uint256 queueTail_
+    ) public returns (uint256 newQueueHead, address controller, uint256 unsettled) {
+        if (requestId >= queueTail_) revert InvalidRequestId();
+        Request storage request = queue[requestId];
+        controller = request.user;
+        if (controller == address(0)) revert RequestNotActive();
+        if (msg.sender != controller && !isOperator[controller][msg.sender])
+            revert NotRequestOwner();
+
+        // A cancelled request must never remain fillable.
+        if (askPlusOne[requestId] != 0) {
+            delete askPlusOne[requestId];
+            emit FillAskCleared(requestId);
+        }
+
+        newQueueHead = queueHead_;
+        unsettled = request.bilAmount - request.bilSettled;
+        if (unsettled > 0) {
+            request.bilAmount = request.bilSettled; // shrink to settled portion
+            emit RedemptionCancelled(requestId, unsettled);
+        }
+
+        // If nothing was settled, the request has nothing left — delete it
+        // and try to compact the queue head. Sweep bounded so the
+        // canceller's gas stays bounded even with many head holes.
+        if (request.bilSettled == 0) {
+            delete queue[requestId];
+            if (requestId == queueHead_) {
+                newQueueHead = advanceQueueHead(
+                    queue,
+                    queueHead_,
+                    queueTail_,
+                    MAX_FILL_ITERATIONS
+                );
+            }
+        }
+    }
+
+    /// @notice Strict-FIFO fill: spend up to `budget` of msg.sender's
+    ///         HOLLAR buying the pending portions of listed requests,
+    ///         head-first, paying each controller directly. Mutates queue
+    ///         entries and asks, then executes all payment legs (CEI within
+    ///         the call); the vault applies `bilFilled` to `totalQueuedBil`,
+    ///         stores `newQueueHead`, and releases the escrowed hDCL. Never
+    ///         touches settled state (`bilSettled`/`hollarOwed`) — a fill
+    ///         is a cancel with a different share destination, not a
+    ///         settlement.
+    ///
+    ///         Skip semantics: holes and pending-zero entries advance the
+    ///         head while co-located (same rules as processQueue). Live
+    ///         entries that are unlisted — or ask a smaller discount than
+    ///         the filler's `minAskBps` — are skipped WITHOUT head advance:
+    ///         the head must never pass a live entry, and an aggressive ask
+    ///         only prices out its own entry, never the queue behind it.
+    function executeFill(
+        mapping(uint256 => Request) storage queue,
+        mapping(uint256 => uint32) storage askPlusOne,
+        IERC20 hollar,
+        uint256 queueHead_,
+        uint256 queueTail_,
+        uint256 budget,
+        uint256 minAskBps,
+        uint256 rate
+    )
+        public
+        returns (
+            uint256 newQueueHead,
+            uint256 hollarSpent,
+            uint256 bilFilled,
+            uint256 count
+        )
+    {
+        // Bound the budget so the share arithmetic (budget × WAD_ × BPS)
+        // cannot overflow on adversarial input.
+        if (budget > type(uint128).max) budget = type(uint128).max;
+
+        newQueueHead = queueHead_;
+        FillPay[] memory pays = new FillPay[](MAX_FILL_ITERATIONS);
+
+        uint256 cursor = queueHead_;
+        uint256 skips;
+
+        while (cursor < queueTail_ && count < MAX_FILL_ITERATIONS && skips < MAX_FILL_SKIPS) {
+            Request storage r = queue[cursor];
+
+            if (r.user == address(0) || r.bilSettled == r.bilAmount) {
+                // Hole, or nothing pending (fully settled / fully filled
+                // earlier) — passable; settled entries stay in the mapping
+                // for claim walkers. Advance head while co-located.
+                if (cursor == newQueueHead) {
+                    unchecked { newQueueHead++; }
+                }
+                unchecked { cursor++; skips++; }
+                continue;
+            }
+
+            uint256 plusOne = askPlusOne[cursor];
+            if (plusOne == 0 || plusOne - 1 < minAskBps) {
+                // Live but not for sale (to this filler) — skip, NO head
+                // advance. Co-location is broken from here on, so the head
+                // naturally freezes before the first live entry.
+                unchecked { cursor++; skips++; }
+                continue;
+            }
+
+            if (budget == 0) break;
+
+            uint256 ask = plusOne - 1;
+            uint256 pending = r.bilAmount - r.bilSettled;
+            address user = r.user; // hoisted: survives a delete below
+
+            // Affordability decided in SHARES, not HOLLAR: with
+            //   sharesAffordable = ⌊budget·wad·BPS / (rate·(BPS−ask))⌋
+            // sharesAffordable ≥ pending ⟹ budget ≥ the double-floored
+            // full price, so the full branch can never overdraw the budget
+            // (deciding on the floored price has a 1-wei corner where the
+            // clamped partial pay would exceed budget).
+            uint256 sharesAffordable = (budget * WAD_ * BPS) / (rate * (BPS - ask));
+            if (sharesAffordable == 0) break; // budget is dust — stop
+
+            if (sharesAffordable >= pending) {
+                // ── full fill ──
+                uint256 pay = _fillPrice(pending, rate, ask);
+                // Catastrophic-rate guard, mirrors processQueue: never
+                // take shares for a zero payout.
+                if (pay == 0) break;
+
+                budget -= pay;
+                r.bilAmount = r.bilSettled; // cancel-shrink of pending
+                delete askPlusOne[cursor];
+                emit FillAskCleared(cursor);
+                if (r.bilSettled == 0) {
+                    delete queue[cursor]; // becomes a hole
+                }
+                // Pending is now zero either way — passable.
+                if (cursor == newQueueHead) {
+                    unchecked { newQueueHead++; }
+                }
+
+                pays[count++] = FillPay(user, pay);
+                hollarSpent += pay;
+                bilFilled += pending;
+                emit RequestFilled(cursor, user, pay, pending);
+                unchecked { cursor++; }
+            } else {
+                // ── partial fill: budget exhausted on this entry ──
+                uint256 pay = _fillPrice(sharesAffordable, rate, ask);
+                if (pay == 0) break;
+
+                r.bilAmount -= sharesAffordable; // pending shrinks in place; ask persists
+
+                pays[count++] = FillPay(user, pay);
+                hollarSpent += pay;
+                bilFilled += sharesAffordable;
+                emit RequestPartiallyFilled(cursor, user, pay, sharesAffordable);
+                break;
+            }
+        }
+
+        // Interactions after all state writes (CEI). HOLLAR has no transfer
+        // hooks; the vault wraps this call in nonReentrant regardless.
+        for (uint256 i; i < count; ++i) {
+            hollar.safeTransferFrom(msg.sender, pays[i].controller, pays[i].amount);
+        }
+        if (count == 0) revert NothingFilled();
+        emit QueueFilled(msg.sender, hollarSpent, bilFilled, count);
+    }
+
+    /// @dev Price of `shares` at `rate` discounted by `ask` bps. Double
+    ///      floor, matching settlement's rounding direction (QueueLib
+    ///      processQueue): sub-wei residue favors the payer (the filler).
+    function _fillPrice(
+        uint256 shares,
+        uint256 rate,
+        uint256 ask
+    ) private pure returns (uint256) {
+        return (((shares * rate) / WAD_) * (BPS - ask)) / BPS;
     }
 
     /// @notice Walk the controller's own settled requests, drawing down

--- a/bil-vault/test/helpers/BaseTest.sol
+++ b/bil-vault/test/helpers/BaseTest.sol
@@ -76,9 +76,9 @@ contract BaseTest is Test, Constants, Events {
     ///      entries can live below queueHead.
     function _claimAll(address user) internal returns (uint256 assets) {
         uint256 totalSettled;
-        uint256 tail = vault.getRedemptionQueueLength();
+        uint256 tail = vault.queueTail();
         for (uint256 i = 0; i < tail; i++) {
-            (address u,, uint256 bilSettled,,) = vault.getRedemptionRequest(i);
+            (address u,, uint256 bilSettled,,,) = vault.getRedemptionRequest(i);
             if (u == user) totalSettled += bilSettled;
         }
         if (totalSettled == 0) return 0;
@@ -91,7 +91,7 @@ contract BaseTest is Test, Constants, Events {
         vault.pokeDecentral(positionIndex);
 
         // Step 2: Approve yield on mock, then execute yield withdrawal
-        (uint256 tokenId,,,,, ) = vault.getPosition(positionIndex);
+        (uint256 tokenId,,,,,,,,) = vault.getPosition(positionIndex);
         pool.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(positionIndex);
 

--- a/bil-vault/test/integration/RealDecentralPool.t.sol
+++ b/bil-vault/test/integration/RealDecentralPool.t.sol
@@ -159,28 +159,27 @@ contract RealDecentralPoolTest is Test {
             ,
             uint256 settledBefore,
             ,
-            bool activeBefore
-        ) = vault.getRedemptionRequest(reqId);
+            bool activeBefore,) = vault.getRedemptionRequest(reqId);
         assertEq(settledBefore, 0, "nothing settled yet");
         assertTrue(activeBefore, "request active");
 
         // pokeQueue with no idle HOLLAR is a no-op — confirm settled stays 0.
         vault.pokeQueue();
-        (, , uint256 settledAfterPoke, , ) = vault.getRedemptionRequest(reqId);
+        (, , uint256 settledAfterPoke, ,,) = vault.getRedemptionRequest(reqId);
         assertEq(settledAfterPoke, 0, "still nothing settled");
 
         // ─── Warp past the 60-day minimum investment period ──────────────
         vm.warp(block.timestamp + 60 days + 1);
 
         // Get the NFT's tokenId. The vault opened the position at index 0.
-        (uint256 tokenId, , , , , uint8 stateBefore) = vault.getPosition(0);
+        (uint256 tokenId, , , , , uint8 stateBefore,,,) = vault.getPosition(0);
         assertEq(stateBefore, 0, "position is Active before maturity poke");
 
         // ─── First poke: Active → YieldWithdrawalRequested ───────────────
         vm.prank(KEEPER);
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 stateAfterFirstPoke) = vault.getPosition(0);
+        (, , , , , uint8 stateAfterFirstPoke,,,) = vault.getPosition(0);
         assertEq(
             stateAfterFirstPoke,
             1,
@@ -202,7 +201,7 @@ contract RealDecentralPoolTest is Test {
         vm.prank(KEEPER);
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 stateAfterSecondPoke) = vault.getPosition(0);
+        (, , , , , uint8 stateAfterSecondPoke,,,) = vault.getPosition(0);
         assertEq(
             stateAfterSecondPoke,
             3,
@@ -210,7 +209,7 @@ contract RealDecentralPoolTest is Test {
         );
 
         // Vault should now hold some HOLLAR (the yield) — it's "idle".
-        uint256 idleAfterYield = vault.getIdleHollar();
+        uint256 idleAfterYield = vault.idleHollar();
         assertGt(idleAfterYield, 0, "vault has idle HOLLAR after yield exec");
 
         // ─── Decentral admin approves principal ─────────────────────────
@@ -226,11 +225,11 @@ contract RealDecentralPoolTest is Test {
         vm.prank(KEEPER);
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 stateAfterPrincipal) = vault.getPosition(0);
+        (, , , , , uint8 stateAfterPrincipal,,,) = vault.getPosition(0);
         assertEq(stateAfterPrincipal, 4, "position is Redeemed");
 
         // Queue should now show our request as fully settled.
-        (, uint256 reqAmount, uint256 settled, uint256 hollarOwed, ) = vault
+        (, uint256 reqAmount, uint256 settled, uint256 hollarOwed, ,) = vault
             .getRedemptionRequest(reqId);
         assertEq(
             settled,
@@ -282,7 +281,7 @@ contract RealDecentralPoolTest is Test {
             "all hDCL returned after cancel"
         );
 
-        (, , , , bool active) = vault.getRedemptionRequest(reqId);
+        (, , , , bool active,) = vault.getRedemptionRequest(reqId);
         assertFalse(active, "request marked inactive after cancel");
     }
 
@@ -296,7 +295,7 @@ contract RealDecentralPoolTest is Test {
         vault.deposit(DEPOSIT, USER);
         vm.stopPrank();
 
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
 
         // Mature + drive state machine to Redeemed (same steps as the happy
         // path but without a queued redemption).
@@ -320,7 +319,7 @@ contract RealDecentralPoolTest is Test {
         // only fires inside `pokeQueue`'s no-progress branch — `pokeDecentral`
         // doesn't trigger it directly.
         assertGt(
-            vault.getIdleHollar(),
+            vault.idleHollar(),
             vault.minReinvestAmount(),
             "idle HOLLAR > min reinvest threshold"
         );
@@ -330,7 +329,7 @@ contract RealDecentralPoolTest is Test {
         // Position 0 closed; reinvestment should have opened position 1.
         assertEq(vault.getPositionCount(), 2, "reinvested into a new position");
 
-        (, , , , , uint8 newState) = vault.getPosition(1);
+        (, , , , , uint8 newState,,,) = vault.getPosition(1);
         assertEq(newState, 0, "new position is Active");
     }
 }

--- a/bil-vault/test/invariant/InvariantVault.t.sol
+++ b/bil-vault/test/invariant/InvariantVault.t.sol
@@ -64,6 +64,11 @@ contract InvariantVaultTest is Test {
         vault.deposit(10_000e18, actors[0]);
 
         // Deploy handlers and helpers
+        // Fills are part of the fuzzed action set — armed here the same
+        // way the mainnet upgrade will arm them post-deploy.
+        vm.prank(admin);
+        vault.setFillsEnabled(true);
+
         userHandler = new UserHandler(vault, hollar, actors);
         keeperHandler = new KeeperHandler(vault, pool);
         posReader = new PositionReader(vault);
@@ -121,7 +126,7 @@ contract InvariantVaultTest is Test {
     function invariant_nftOwnership() public view {
         uint256 count = vault.getPositionCount();
         for (uint256 i = 0; i < count; i++) {
-            (uint256 tokenId, , , , , uint8 state) = vault.getPosition(i);
+            (uint256 tokenId, , , , , uint8 state,,,) = vault.getPosition(i);
             if (state != 4) {
                 assertEq(
                     nft.ownerOf(tokenId),
@@ -156,7 +161,7 @@ contract InvariantVaultTest is Test {
     function invariant_validPositionStates() public view {
         uint256 count = vault.getPositionCount();
         for (uint256 i = 0; i < count; i++) {
-            (, , , , , uint8 state) = vault.getPosition(i);
+            (, , , , , uint8 state,,,) = vault.getPosition(i);
             assertLe(state, 4, "INV-6: invalid position state");
         }
     }
@@ -170,7 +175,7 @@ contract InvariantVaultTest is Test {
         uint256 count = vault.getPositionCount();
         uint256 sumPrincipal = 0;
         for (uint256 i = 0; i < count; i++) {
-            (, uint256 principal, , , , uint8 state) = vault.getPosition(i);
+            (, uint256 principal, , , , uint8 state,,,) = vault.getPosition(i);
             if (state != 4) {
                 sumPrincipal += principal;
             }
@@ -190,7 +195,7 @@ contract InvariantVaultTest is Test {
     function invariant_positionHeadValid() public view {
         uint256 head = vault.getPositionHead();
         for (uint256 i = 0; i < head; i++) {
-            (, , , , , uint8 state) = vault.getPosition(i);
+            (, , , , , uint8 state,,,) = vault.getPosition(i);
             assertEq(state, 4, "INV-8: non-redeemed position before head");
         }
     }
@@ -217,10 +222,10 @@ contract InvariantVaultTest is Test {
 
     /// @notice totalReservedHollar == sum of hollarOwed across all non-deleted requests.
     function invariant_totalReservedHollarAccurate() public view {
-        uint256 tail = vault.getRedemptionQueueLength();
+        uint256 tail = vault.queueTail();
         uint256 sum = 0;
         for (uint256 i = 0; i < tail; i++) {
-            (address u, , , uint256 owed, ) = vault.getRedemptionRequest(i);
+            (address u, , , uint256 owed,,) = vault.getRedemptionRequest(i);
             if (u != address(0)) sum += owed;
         }
         assertEq(
@@ -236,10 +241,10 @@ contract InvariantVaultTest is Test {
 
     /// @notice totalQueuedBil == sum of bilAmount across all non-deleted requests.
     function invariant_totalQueuedBilAccurate() public view {
-        uint256 tail = vault.getRedemptionQueueLength();
+        uint256 tail = vault.queueTail();
         uint256 sum = 0;
         for (uint256 i = 0; i < tail; i++) {
-            (address u, uint256 amt, , , ) = vault.getRedemptionRequest(i);
+            (address u, uint256 amt, , ,,) = vault.getRedemptionRequest(i);
             if (u != address(0)) sum += amt;
         }
         assertEq(
@@ -273,9 +278,9 @@ contract InvariantVaultTest is Test {
     ///         hollarOwed > 0 only if bilSettled > 0 (no HOLLAR locked for
     ///         zero shares).
     function invariant_perRequestConsistency() public view {
-        uint256 tail = vault.getRedemptionQueueLength();
+        uint256 tail = vault.queueTail();
         for (uint256 i = 0; i < tail; i++) {
-            (address u, uint256 amt, uint256 settled, uint256 owed, ) =
+            (address u, uint256 amt, uint256 settled, uint256 owed,,) =
                 vault.getRedemptionRequest(i);
             if (u == address(0)) continue;
             assertLe(settled, amt, "INV-13a: bilSettled > bilAmount");
@@ -295,7 +300,7 @@ contract InvariantVaultTest is Test {
     function invariant_positionPoolIntegrity() public view {
         uint256 count = vault.getPositionCount();
         for (uint256 i = 0; i < count; i++) {
-            (, , , , , uint8 state) = vault.getPosition(i);
+            (, , , , , uint8 state,,,) = vault.getPosition(i);
             if (state == 4) continue;
             assertTrue(
                 vault.isPoolRegistered(vault.positionPool(i)),

--- a/bil-vault/test/invariant/handlers/KeeperHandler.sol
+++ b/bil-vault/test/invariant/handlers/KeeperHandler.sol
@@ -44,7 +44,7 @@ contract KeeperHandler is Test {
         uint256 idx = positionSeed % count;
 
         // Skip if already redeemed
-        (, , , , , uint8 state) = vault.getPosition(idx);
+        (, , , , , uint8 state,,,) = vault.getPosition(idx);
         if (state == 4) return;
 
         vault.pokeDecentral(idx);
@@ -59,12 +59,12 @@ contract KeeperHandler is Test {
         if (count == 0) return;
 
         uint256 idx = positionSeed % count;
-        (, , , , , uint8 state) = vault.getPosition(idx);
+        (, , , , , uint8 state,,,) = vault.getPosition(idx);
 
         // Only approve if in YieldWithdrawalRequested
         if (state != 1) return;
 
-        (uint256 tokenId, , , , , ) = vault.getPosition(idx);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(idx);
         pool.approveYieldWithdrawal(tokenId);
     }
 
@@ -75,12 +75,12 @@ contract KeeperHandler is Test {
         if (count == 0) return;
 
         uint256 idx = positionSeed % count;
-        (, , , , , uint8 state) = vault.getPosition(idx);
+        (, , , , , uint8 state,,,) = vault.getPosition(idx);
 
         // Only approve if in PrincipalWithdrawalRequested
         if (state != 3) return;
 
-        (uint256 tokenId, , , , , ) = vault.getPosition(idx);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(idx);
         pool.approvePrincipalWithdrawal(tokenId);
     }
 
@@ -112,7 +112,7 @@ contract KeeperHandler is Test {
         if (count == 0) return;
 
         uint256 idx = positionSeed % count;
-        (uint256 tokenId, uint256 principal, , , , uint8 state) = vault.getPosition(idx);
+        (uint256 tokenId, uint256 principal, , , , uint8 state,,,) = vault.getPosition(idx);
 
         // Only meaningful while the position can still pass through
         // executePrincipalWithdrawal (state != Redeemed).

--- a/bil-vault/test/invariant/handlers/UserHandler.sol
+++ b/bil-vault/test/invariant/handlers/UserHandler.sol
@@ -90,7 +90,7 @@ contract UserHandler is Test {
         address owner = requestOwner[requestId];
 
         // Check if still active
-        (address user, , , , bool active) = vault.getRedemptionRequest(requestId);
+        (address user, , , , bool active,) = vault.getRedemptionRequest(requestId);
         if (!active || user == address(0)) {
             _removeRequestAt(idx);
             return;
@@ -100,6 +100,54 @@ contract UserHandler is Test {
         vault.cancelRedeem(requestId);
         _removeRequestAt(idx);
     }
+
+    // ── Queue fills ────────────────────────────────────────────────────────
+
+    address internal constant FILLER = address(0xF111e5);
+
+    /// @notice Random controller lists (or re-prices / delists) a random
+    ///         active request.
+    function setFillAsk(uint256 seed, uint32 askBps) external {
+        if (activeRequestIds.length == 0) return;
+        uint256 requestId = activeRequestIds[seed % activeRequestIds.length];
+        address owner = requestOwner[requestId];
+        (address user, , , , bool active,) = vault.getRedemptionRequest(requestId);
+        if (!active || user == address(0)) return;
+
+        // Mostly valid asks, occasionally the delist sentinel.
+        askBps = askBps % 100 == 0 ? type(uint32).max : askBps % 2_001;
+
+        vm.prank(owner);
+        try vault.setFillAsk(requestId, askBps) {
+            ghost_askSets++;
+        } catch {
+            // NothingPending on fully-settled entries etc. — fine.
+        }
+    }
+
+    /// @notice A dedicated filler buys listed queue entries head-first.
+    function fillQueue(uint256 budget, uint32 minAskBps) external {
+        budget = bound(budget, 1e18, 500_000e18);
+        minAskBps = minAskBps % 2_001;
+
+        hollar.mint(FILLER, budget);
+        vm.prank(FILLER);
+        hollar.approve(address(vault), budget);
+
+        vm.prank(FILLER);
+        try vault.fillQueue(budget, minAskBps) returns (uint256 spent, uint256 got) {
+            ghost_hollarFilled += spent;
+            ghost_bilFilled += got;
+            ghost_fillCount++;
+        } catch {
+            // NothingFilled / paused / backlog — fine under fuzz.
+        }
+    }
+
+    uint256 public ghost_askSets;
+    uint256 public ghost_fillCount;
+    uint256 public ghost_hollarFilled;
+    uint256 public ghost_bilFilled;
 
     function _removeRequestAt(uint256 idx) internal {
         activeRequestIds[idx] = activeRequestIds[activeRequestIds.length - 1];
@@ -120,9 +168,9 @@ contract UserHandler is Test {
 
         // Sum the actor's claimable across all open requests.
         uint256 totalClaimable;
-        uint256 tail = vault.getRedemptionQueueLength();
+        uint256 tail = vault.queueTail();
         for (uint256 i = 0; i < tail; i++) {
-            (address u,, uint256 settled,,) = vault.getRedemptionRequest(i);
+            (address u,, uint256 settled,,,) = vault.getRedemptionRequest(i);
             if (u == actor) totalClaimable += settled;
         }
         if (totalClaimable == 0) return;

--- a/bil-vault/test/invariant/helpers/PositionReader.sol
+++ b/bil-vault/test/invariant/helpers/PositionReader.sol
@@ -13,10 +13,10 @@ contract PositionReader {
     }
 
     function principal(uint256 idx) external view returns (uint256 _principal) {
-        (, _principal,,,,,,,) = vault.positions(idx);
+        (, _principal,,,,,,,) = vault.getPosition(idx);
     }
 
     function pendingYield(uint256 idx) external view returns (uint256 _pendingYield) {
-        (,,,,,,,, _pendingYield) = vault.positions(idx);
+        (,,,,,,, _pendingYield,) = vault.getPosition(idx);
     }
 }

--- a/bil-vault/test/unit/Admin.t.sol
+++ b/bil-vault/test/unit/Admin.t.sol
@@ -169,7 +169,7 @@ contract AdminTest is BaseTest {
         // pokeDecentral still works (warp past maturity)
         _warpDays(61);
         vault.pokeDecentral(0);
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 1, "Position advances even with deposits paused");
     }
 

--- a/bil-vault/test/unit/DecentralPrincipalShockCircuitBreaker.t.sol
+++ b/bil-vault/test/unit/DecentralPrincipalShockCircuitBreaker.t.sol
@@ -205,7 +205,7 @@ contract DecentralPrincipalShockCircuitBreakerTest is BaseTest {
     }
 
     function _tokenIdOf(uint256 positionIndex) internal view returns (uint256) {
-        (uint256 tokenId, , , , , ) = vault.getPosition(positionIndex);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(positionIndex);
         return tokenId;
     }
 }

--- a/bil-vault/test/unit/Deposit.t.sol
+++ b/bil-vault/test/unit/Deposit.t.sol
@@ -248,8 +248,7 @@ contract DepositTest is BaseTest {
             uint256 apyWad,
             uint256 depositTime,
             uint256 maturityTime,
-            uint8 state
-        ) = vault.getPosition(0);
+            uint8 state,,,) = vault.getPosition(0);
 
         assertGt(tokenId, 0, "Token ID > 0");
         assertEq(principal, TEN_THOUSAND_HOLLAR, "Principal matches deposit amount");
@@ -263,7 +262,7 @@ contract DepositTest is BaseTest {
     function test_deposit_vaultOwnsNFT() public {
         _deposit(alice, TEN_THOUSAND_HOLLAR);
 
-        (uint256 tokenId,,,,, ) = vault.getPosition(0);
+        (uint256 tokenId,,,,,,,,) = vault.getPosition(0);
         assertEq(nft.ownerOf(tokenId), address(vault), "Vault owns the Decentral NFT");
     }
 

--- a/bil-vault/test/unit/EstimatedWaitTime.t.sol
+++ b/bil-vault/test/unit/EstimatedWaitTime.t.sol
@@ -7,22 +7,11 @@ import {BILVault} from "../../src/BILVault.sol";
 /// @title getEstimatedWaitTime — View Liveness
 contract EstimatedWaitTimeTest is BaseTest {
     function _readYieldStartTime(uint256 idx) internal view returns (uint256 yst) {
-        // NFTPosition layout offsets (see BILVault struct):
-        //   slot 0: tokenId, 1: principal, 2: apyWad, 3: depositTime,
-        //   slot 4: maturityTime, 5: yieldStartTime, ...
-        (bool ok, bytes memory data) = address(vault).staticcall(
-            abi.encodeWithSignature("positions(uint256)", idx)
-        );
-        require(ok);
-        assembly { yst := mload(add(data, 192)) }
+        (,,,,,,,, yst) = vault.getPosition(idx);
     }
 
     function _readMaturityTime(uint256 idx) internal view returns (uint256 m) {
-        (bool ok, bytes memory data) = address(vault).staticcall(
-            abi.encodeWithSignature("positions(uint256)", idx)
-        );
-        require(ok);
-        assembly { m := mload(add(data, 160)) }
+        (,,,, m,,,,) = vault.getPosition(idx);
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/bil-vault/test/unit/ExchangeRate.t.sol
+++ b/bil-vault/test/unit/ExchangeRate.t.sol
@@ -127,7 +127,7 @@ contract ExchangeRateTest is BaseTest {
         vault.pokeDecentral(0);
 
         // Approve and execute yield withdrawal
-        (uint256 tokenId,,,,, ) = vault.getPosition(0);
+        (uint256 tokenId,,,,,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(0);
 

--- a/bil-vault/test/unit/MaturityCheckpoint.t.sol
+++ b/bil-vault/test/unit/MaturityCheckpoint.t.sol
@@ -99,7 +99,7 @@ contract MaturityCheckpointTest is BaseTest {
         uint256 requestId = _requestRedeem(bob, vault.balanceOf(bob));
         vm.expectRevert(BILVault.MaturityBacklog.selector);
         vault.pokeQueue();
-        (, , uint256 settledBefore, uint256 owedBefore, ) = vault
+        (, , uint256 settledBefore, uint256 owedBefore, ,) = vault
             .getRedemptionRequest(requestId);
         assertEq(settledBefore, 0, "queue cannot lock a conservative rate");
         assertEq(owedBefore, 0, "no HOLLAR reserved while backlog remains");
@@ -115,7 +115,7 @@ contract MaturityCheckpointTest is BaseTest {
         assertEq(vault.getPositionCount(), countBefore + 1, "deposit resumes after backlog fits bound");
 
         vault.pokeQueue();
-        (, , uint256 settledAfter, , ) = vault.getRedemptionRequest(requestId);
+        (, , uint256 settledAfter, ,,) = vault.getRedemptionRequest(requestId);
         assertGt(settledAfter, 0, "queue resumes at the exact synchronized rate");
     }
 
@@ -129,7 +129,7 @@ contract MaturityCheckpointTest is BaseTest {
         assertEq(vault.syncMaturities(1), 0, "heap entry cannot be removed twice");
         assertEq(vault.totalPendingYield(), 0, "zero-yield sync is idempotent");
         vault.pokeDecentral(0);
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 3, "zero-yield position advances to principal request");
     }
 
@@ -239,12 +239,12 @@ contract MaturityCheckpointTest is BaseTest {
     }
 
     function _assertCapped(uint256 idx) internal view {
-        (, , , , , , , bool capped, ) = vault.positions(idx);
+        (, , , , , , bool capped,,) = vault.getPosition(idx);
         assertTrue(capped, "position should be capped");
     }
 
     function _assertLive(uint256 idx) internal view {
-        (, , , , , , , bool capped, ) = vault.positions(idx);
+        (, , , , , , bool capped,,) = vault.getPosition(idx);
         assertFalse(capped, "position should still be live");
     }
 
@@ -269,6 +269,6 @@ contract MaturityCheckpointTest is BaseTest {
     }
 
     function _pendingYield(uint256 positionIndex) internal view returns (uint256 pending) {
-        (, , , , , , , , pending) = vault.positions(positionIndex);
+        (, , , , , , , pending,) = vault.getPosition(positionIndex);
     }
 }

--- a/bil-vault/test/unit/MultiPool.t.sol
+++ b/bil-vault/test/unit/MultiPool.t.sol
@@ -168,19 +168,19 @@ contract MultiPoolTest is BaseTest {
 
         // Process position 0 (pool 1) all the way to Redeemed
         _processPositionFull(0);
-        (, , , , , uint8 state0) = vault.getPosition(0);
+        (, , , , , uint8 state0,,,) = vault.getPosition(0);
         assertEq(state0, 4, "position 0 redeemed");
 
         // Process position 1 (pool 2) — it should route through pool2, not the
         // original pool. If routing were stuck on pool 1, pool 1 wouldn't have
         // a yield request for token id 1.
         vault.pokeDecentral(1);
-        (uint256 tokenId1, , , , , uint8 state1) = vault.getPosition(1);
+        (uint256 tokenId1, , , , , uint8 state1,,,) = vault.getPosition(1);
         assertEq(state1, 1, "position 1 advanced to YWR via its own pool");
 
         pool2.approveYieldWithdrawal(tokenId1);
         vault.pokeDecentral(1);
-        (, , , , , uint8 state1b) = vault.getPosition(1);
+        (, , , , , uint8 state1b,,,) = vault.getPosition(1);
         assertEq(state1b, 3, "position 1 advanced to PWR via pool2");
     }
 

--- a/bil-vault/test/unit/MultiPoolHeterogeneousAPY.t.sol
+++ b/bil-vault/test/unit/MultiPoolHeterogeneousAPY.t.sol
@@ -69,7 +69,7 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
     ///      lets multi-pool tests target the right pool for each position.
     function _processPositionFullVia(uint256 positionIndex, MockDecentralPool poolImpl) internal {
         vault.pokeDecentral(positionIndex);
-        (uint256 tokenId, , , , , ) = vault.getPosition(positionIndex);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(positionIndex);
         poolImpl.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(positionIndex);
         poolImpl.approvePrincipalWithdrawal(tokenId);
@@ -85,7 +85,7 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
         // T=0: alice deposits → position 0 in pool 1 (18%)
         _deposit(alice, 10_000e18);
         assertEq(address(vault.positionPool(0)), address(pool));
-        (, , uint256 apy0, , , ) = vault.getPosition(0);
+        (, , uint256 apy0, , ,,,,) = vault.getPosition(0);
         assertEq(apy0, APY_18_PERCENT, "pos 0 snapshots 18%");
 
         // T=30d: switch to pool 2 (22%); bob and carol deposit
@@ -98,8 +98,8 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
         // Pool anchors + APY snapshots
         assertEq(address(vault.positionPool(1)), address(pool22), "pos 1 in pool 2");
         assertEq(address(vault.positionPool(2)), address(pool22), "pos 2 in pool 2");
-        (, , uint256 apy1, , , ) = vault.getPosition(1);
-        (, , uint256 apy2, , , ) = vault.getPosition(2);
+        (, , uint256 apy1, , ,,,,) = vault.getPosition(1);
+        (, , uint256 apy2, , ,,,,) = vault.getPosition(2);
         assertEq(apy1, APY_22, "pos 1 snapshots 22%");
         assertEq(apy2, APY_22, "pos 2 snapshots 22%");
     }
@@ -178,17 +178,17 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
 
         // Process pos 0 fully (via pool 1)
         _processPositionFull(0);
-        (, , , , , uint8 state0) = vault.getPosition(0);
+        (, , , , , uint8 state0,,,) = vault.getPosition(0);
         assertEq(state0, 4, "pos 0 redeemed via pool 1");
 
         // Pos 1 should still be Active
-        (, , , , , uint8 state1) = vault.getPosition(1);
+        (, , , , , uint8 state1,,,) = vault.getPosition(1);
         assertEq(state1, 0, "pos 1 still active, not yet matured");
 
         // Warp past pos 1's maturity (at t=30d + 60d = t=90d)
         _warpDays(30); // t = 95d
         _processPositionFullVia(1, pool22);
-        (, , , , , uint8 state1b) = vault.getPosition(1);
+        (, , , , , uint8 state1b,,,) = vault.getPosition(1);
         assertEq(state1b, 4, "pos 1 redeemed via pool 2");
     }
 
@@ -264,7 +264,7 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
         vault.pokeQueue();
 
         // Bob's settled HOLLAR should match the rate-lock at settlement time
-        (, , uint256 settled, uint256 owed, ) = vault.getRedemptionRequest(bobReq);
+        (, , uint256 settled, uint256 owed,,) = vault.getRedemptionRequest(bobReq);
         uint256 expectedOwed = (settled * rateAtSettle) / 1e18;
         assertApproxEqRel(owed, expectedOwed, 0.001e18, "rate-lock matches exchangeRate at settle");
 
@@ -305,13 +305,13 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
 
         // FIFO: alice (req 0) settles first. If idle covers her in full, her
         // claimable should equal her requested amount. If not, partial.
-        (, , uint256 aliceSettled, , ) = vault.getRedemptionRequest(0);
+        (, , uint256 aliceSettled, ,,) = vault.getRedemptionRequest(0);
         if (aliceSettled == aliceBil / 2) {
             // alice fully settled — bob may be partial or fully settled too
             assertGt(idleSnapshot, 0, "had idle to settle alice fully");
         } else {
             // alice partially settled — bob should be 0
-            (, , uint256 bobSettled, , ) = vault.getRedemptionRequest(1);
+            (, , uint256 bobSettled, ,,) = vault.getRedemptionRequest(1);
             assertEq(bobSettled, 0, "bob untouched until alice fully settled");
         }
     }
@@ -403,9 +403,9 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
         assertEq(address(vault.positionPool(0)), address(pool));
         assertEq(address(vault.positionPool(1)), address(pool22));
         assertEq(address(vault.positionPool(2)), address(pool16));
-        (, , uint256 apy0, , , ) = vault.getPosition(0);
-        (, , uint256 apy1, , , ) = vault.getPosition(1);
-        (, , uint256 apy2, , , ) = vault.getPosition(2);
+        (, , uint256 apy0, , ,,,,) = vault.getPosition(0);
+        (, , uint256 apy1, , ,,,,) = vault.getPosition(1);
+        (, , uint256 apy2, , ,,,,) = vault.getPosition(2);
         assertEq(apy0, APY_18_PERCENT);
         assertEq(apy1, APY_22);
         assertEq(apy2, APY_16);
@@ -473,7 +473,7 @@ contract MultiPoolHeterogeneousAPYTest is BaseTest {
 
         // Now charlie deposits under the 16% regime
         _deposit(charlie, 10_000e18);
-        (, , uint256 apy2, , , ) = vault.getPosition(2);
+        (, , uint256 apy2, , ,,,,) = vault.getPosition(2);
         assertEq(apy2, APY_16, "new deposit gets the cut rate");
 
         // The blended rate continues to grow — slower than before — but

--- a/bil-vault/test/unit/OperatorAndAutoClaim.t.sol
+++ b/bil-vault/test/unit/OperatorAndAutoClaim.t.sol
@@ -57,7 +57,7 @@ contract OperatorAndAutoClaimTest is BaseTest {
         uint256 reqId = vault.requestRedeem(aliceBil / 4, alice, alice);
 
         // Alice's hDCL was escrowed, request is alice's
-        (address controller, , , ,) = vault.getRedemptionRequest(reqId);
+        (address controller, , , ,,) = vault.getRedemptionRequest(reqId);
         assertEq(controller, alice);
     }
 
@@ -109,7 +109,7 @@ contract OperatorAndAutoClaimTest is BaseTest {
 
     function test_withdraw_byOperator_works() public {
         _settleAlice();
-        (,,, uint256 owed,) = vault.getRedemptionRequest(0);
+        (,,, uint256 owed,,) = vault.getRedemptionRequest(0);
 
         vm.prank(alice);
         vault.setOperator(bob, true);
@@ -206,7 +206,7 @@ contract OperatorAndAutoClaimTest is BaseTest {
         _grantClaimOperator();
 
         // Claim once (succeeds)
-        (,, uint256 settled1,,) = vault.getRedemptionRequest(0);
+        (,, uint256 settled1,,,) = vault.getRedemptionRequest(0);
         vm.prank(keeperBot);
         vault.redeem(settled1, alice, alice);
 
@@ -220,8 +220,8 @@ contract OperatorAndAutoClaimTest is BaseTest {
         vault.setAutoClaim(false);
 
         // Keeper can no longer claim
-        uint256 reqId = vault.getRedemptionQueueLength() - 1;
-        (,, uint256 settled2,,) = vault.getRedemptionRequest(reqId);
+        uint256 reqId = vault.queueTail() - 1;
+        (,, uint256 settled2,,,) = vault.getRedemptionRequest(reqId);
         if (settled2 > 0) {
             vm.prank(keeperBot);
             vm.expectRevert(BILVault.NotAuthorized.selector);

--- a/bil-vault/test/unit/PostMaturityYieldDrift.t.sol
+++ b/bil-vault/test/unit/PostMaturityYieldDrift.t.sol
@@ -83,7 +83,7 @@ contract PostMaturityYieldDriftTest is BaseTest {
         assertEq(vault.totalPendingYield(), pendingBefore, "no pending yield locked pre-maturity");
 
         // The position is still Active and uncapped (pendingYield == 0).
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 0, "still Active");
     }
 
@@ -110,7 +110,7 @@ contract PostMaturityYieldDriftTest is BaseTest {
         // Active → YieldWithdrawalRequested. With the fix, pendingYield is the
         // 60-day capped projection regardless of how late the poke is.
         vault.pokeDecentral(0);
-        (, , , , , uint8 stateAfter) = vault.getPosition(0);
+        (, , , , , uint8 stateAfter,,,) = vault.getPosition(0);
         assertEq(stateAfter, 1, "state is YieldWithdrawalRequested"); // enum index 1
 
         uint256 totalPendingAfterRequest = vault.totalPendingYield();
@@ -185,7 +185,7 @@ contract PostMaturityYieldDriftTest is BaseTest {
         uint256 reqId = _requestRedeem(bob, bobShares);
         vault.pokeQueue();
 
-        (, uint256 bilAmount, uint256 bilSettled, uint256 hollarOwed, ) = vault
+        (, uint256 bilAmount, uint256 bilSettled, uint256 hollarOwed, ,) = vault
             .getRedemptionRequest(reqId);
         assertEq(bilAmount, bobShares, "request bilAmount = full shares");
         assertGt(bilSettled, 0, "at least partial settle from idleHollar");
@@ -196,7 +196,7 @@ contract PostMaturityYieldDriftTest is BaseTest {
     }
 
     function _tokenIdOf(uint256 positionIndex) internal view returns (uint256) {
-        (uint256 tokenId, , , , , ) = vault.getPosition(positionIndex);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(positionIndex);
         return tokenId;
     }
 }

--- a/bil-vault/test/unit/PrincipalMismatch.t.sol
+++ b/bil-vault/test/unit/PrincipalMismatch.t.sol
@@ -60,7 +60,7 @@ contract PrincipalMismatchTest is BaseTest {
         _warpDays(61);
 
         vault.pokeDecentral(0); // Active → YWR
-        (tokenId,,,,,) = vault.getPosition(0);
+        (tokenId,,,,,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(0); // YWR → YC → PWR cascade
         pool.approvePrincipalWithdrawal(tokenId);
@@ -81,7 +81,7 @@ contract PrincipalMismatchTest is BaseTest {
         assertEq(ms.length, 0, "no PrincipalMismatch event when payout is exact");
 
         // Sanity: position is Redeemed
-        (,,,,, uint8 state) = vault.getPosition(0);
+        (,,,,, uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 4, "position redeemed");
         tokenId; // suppress unused
     }

--- a/bil-vault/test/unit/ProcessPosition.t.sol
+++ b/bil-vault/test/unit/ProcessPosition.t.sol
@@ -27,7 +27,7 @@ contract ProcessPositionTest is BaseTest {
         // Process: Active -> YieldWithdrawalRequested
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 1, "State should be YieldWithdrawalRequested (1)");
     }
 
@@ -43,7 +43,7 @@ contract ProcessPositionTest is BaseTest {
         vault.pokeDecentral(0);
 
         // Approve yield on mock pool
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
 
         uint256 idleBefore = vault.idleHollar();
@@ -55,7 +55,7 @@ contract ProcessPositionTest is BaseTest {
         uint256 idleAfter = vault.idleHollar();
         assertGt(idleAfter, idleBefore, "idleHollar should increase after yield claim");
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         // After yield claim, it immediately transitions to PrincipalWithdrawalRequested
         assertEq(state, 3, "State should be PrincipalWithdrawalRequested (3) after yield claim");
     }
@@ -72,13 +72,13 @@ contract ProcessPositionTest is BaseTest {
         vault.pokeDecentral(0);
 
         // Approve yield
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
 
         // This single call should execute yield, then immediately request principal
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(
             state,
             3,
@@ -98,7 +98,7 @@ contract ProcessPositionTest is BaseTest {
         vault.pokeDecentral(0);
 
         // Approve yield and process (-> PrincipalWithdrawalRequested)
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(0);
 
@@ -114,7 +114,7 @@ contract ProcessPositionTest is BaseTest {
         uint256 idleAfter = vault.idleHollar();
         assertGt(idleAfter, idleBefore, "idleHollar should increase after principal redemption");
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 4, "State should be Redeemed (4)");
     }
 
@@ -131,16 +131,16 @@ contract ProcessPositionTest is BaseTest {
 
         // Step 2: Active -> YieldWithdrawalRequested
         vault.pokeDecentral(0);
-        (, , , , , uint8 s1) = vault.getPosition(0);
+        (, , , , , uint8 s1,,,) = vault.getPosition(0);
         assertEq(s1, 1, "After step 2: YieldWithdrawalRequested");
 
         // Step 3: Approve yield on mock pool
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
 
         // Step 4: Execute yield + request principal (single call)
         vault.pokeDecentral(0);
-        (, , , , , uint8 s2) = vault.getPosition(0);
+        (, , , , , uint8 s2,,,) = vault.getPosition(0);
         assertEq(s2, 3, "After step 4: PrincipalWithdrawalRequested");
 
         // Step 5: Approve principal and warp past 48h
@@ -149,7 +149,7 @@ contract ProcessPositionTest is BaseTest {
 
         // Step 6: Execute principal -> Redeemed
         vault.pokeDecentral(0);
-        (, , , , , uint8 s3) = vault.getPosition(0);
+        (, , , , , uint8 s3,,,) = vault.getPosition(0);
         assertEq(s3, 4, "After step 6: Redeemed");
 
         // Step 7: Verify total HOLLAR returned = principal + yield
@@ -178,7 +178,7 @@ contract ProcessPositionTest is BaseTest {
         // Call processPosition -- should NOT advance state (no-op for active before maturity)
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 0, "State should remain Active (0) before maturity");
     }
 
@@ -193,7 +193,7 @@ contract ProcessPositionTest is BaseTest {
         // Process fully through all states
         _processPositionFull(0);
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 4, "Position should be Redeemed");
 
         // Attempt to process again should revert
@@ -211,7 +211,7 @@ contract ProcessPositionTest is BaseTest {
 
         // Active -> YieldWithdrawalRequested
         vault.pokeDecentral(0);
-        (, , , , , uint8 s1) = vault.getPosition(0);
+        (, , , , , uint8 s1,,,) = vault.getPosition(0);
         assertEq(s1, 1, "Should be YieldWithdrawalRequested");
 
         // DO NOT approve yield on mock pool
@@ -220,7 +220,7 @@ contract ProcessPositionTest is BaseTest {
         // caught by try/catch, so it returns without advancing state
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 s2) = vault.getPosition(0);
+        (, , , , , uint8 s2,,,) = vault.getPosition(0);
         assertEq(s2, 1, "State should remain YieldWithdrawalRequested when not approved");
     }
 
@@ -258,7 +258,7 @@ contract ProcessPositionTest is BaseTest {
 
         // Track vault HOLLAR balance to detect yield received
         vault.pokeDecentral(0);
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
 
         uint256 idleBefore = vault.idleHollar();
@@ -351,19 +351,19 @@ contract ProcessPositionTest is BaseTest {
 
         // Process position 0 -- should work (past 60 days)
         vault.pokeDecentral(0);
-        (, , , , , uint8 state0) = vault.getPosition(0);
+        (, , , , , uint8 state0,,,) = vault.getPosition(0);
         assertEq(state0, 1, "Position 0 should advance to YieldWithdrawalRequested");
 
         // Process position 1 -- should no-op (only 51 days)
         vault.pokeDecentral(1);
-        (, , , , , uint8 state1) = vault.getPosition(1);
+        (, , , , , uint8 state1,,,) = vault.getPosition(1);
         assertEq(state1, 0, "Position 1 should remain Active (not yet mature)");
 
         // Warp 10 more days so position 1 matures
         _warpDays(10);
 
         vault.pokeDecentral(1);
-        (, , , , , uint8 state1b) = vault.getPosition(1);
+        (, , , , , uint8 state1b,,,) = vault.getPosition(1);
         assertEq(state1b, 1, "Position 1 should now advance to YieldWithdrawalRequested");
     }
 
@@ -384,13 +384,13 @@ contract ProcessPositionTest is BaseTest {
         pool.setRevertOnRequestYield(true);
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 0, "Position stays Active when requestYield reverts");
 
         // Recovery: clear the flag and the next poke advances normally.
         pool.setRevertOnRequestYield(false);
         vault.pokeDecentral(0);
-        (, , , , , uint8 state2) = vault.getPosition(0);
+        (, , , , , uint8 state2,,,) = vault.getPosition(0);
         assertEq(state2, 1, "Position advances after pool recovers");
     }
 
@@ -409,7 +409,7 @@ contract ProcessPositionTest is BaseTest {
         pool.setRevertOnRequestPrincipal(true);
 
         vault.pokeDecentral(0);
-        (uint256 tokenId, , , , , uint8 sA) = vault.getPosition(0);
+        (uint256 tokenId, , , , , uint8 sA,,,) = vault.getPosition(0);
         assertEq(sA, 1, "Position is YieldWithdrawalRequested");
 
         // Approve yield, then poke again: executes yield -> YieldClaimed,
@@ -417,7 +417,7 @@ contract ProcessPositionTest is BaseTest {
         // The catch returns and leaves state at YieldClaimed.
         pool.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(0);
-        (, , , , , uint8 sB) = vault.getPosition(0);
+        (, , , , , uint8 sB,,,) = vault.getPosition(0);
         assertEq(sB, 2, "Position is YieldClaimed (request-principal caught)");
 
         // Idle HOLLAR should reflect the yield payout — yield exec ran fine.
@@ -426,7 +426,7 @@ contract ProcessPositionTest is BaseTest {
         // Recovery: clear the flag and the next poke advances to PWR.
         pool.setRevertOnRequestPrincipal(false);
         vault.pokeDecentral(0);
-        (, , , , , uint8 sC) = vault.getPosition(0);
+        (, , , , , uint8 sC,,,) = vault.getPosition(0);
         assertEq(sC, 3, "Position advances to PrincipalWithdrawalRequested");
     }
 
@@ -462,7 +462,7 @@ contract ProcessPositionTest is BaseTest {
         assertEq(vault.maxRedeem(alice), claimableShares, "maxRedeem == bilSettled sum");
 
         // maxWithdraw matches the reserved HOLLAR for those shares.
-        (, , , uint256 hollarOwed, ) = vault.getRedemptionRequest(reqId);
+        (, , , uint256 hollarOwed,,) = vault.getRedemptionRequest(reqId);
         assertEq(vault.maxWithdraw(alice), hollarOwed, "maxWithdraw == hollarOwed sum");
 
         // Unrelated address sees 0.

--- a/bil-vault/test/unit/PullRedemption.t.sol
+++ b/bil-vault/test/unit/PullRedemption.t.sol
@@ -45,7 +45,7 @@ contract PullRedemptionTest is BaseTest {
         assertGt(vault.totalReservedHollar(), 0, "reserved increased");
 
         // Request is rate-locked: bilSettled == bilAmount
-        (, uint256 amt, uint256 settled, uint256 owed,) = vault.getRedemptionRequest(requestId);
+        (, uint256 amt, uint256 settled, uint256 owed,,) = vault.getRedemptionRequest(requestId);
         assertEq(settled, amt, "fully settled");
         assertGt(owed, 0, "HOLLAR locked for claim");
     }
@@ -177,7 +177,7 @@ contract PullRedemptionTest is BaseTest {
         vault.pokeQueue();
 
         // Get the request's owed HOLLAR
-        (,,, uint256 owed,) = vault.getRedemptionRequest(0);
+        (,,, uint256 owed,,) = vault.getRedemptionRequest(0);
 
         uint256 aliceHollarBefore = hollar.balanceOf(alice);
 
@@ -207,7 +207,7 @@ contract PullRedemptionTest is BaseTest {
         // pokeQueue partially settles bob
         vault.pokeQueue();
 
-        (, uint256 amt, uint256 settledBefore, uint256 owedBefore,) = vault.getRedemptionRequest(reqId);
+        (, uint256 amt, uint256 settledBefore, uint256 owedBefore,,) = vault.getRedemptionRequest(reqId);
         assertGt(settledBefore, 0, "partially settled");
         assertLt(settledBefore, amt, "not fully settled");
 
@@ -221,7 +221,7 @@ contract PullRedemptionTest is BaseTest {
         assertEq(bobBilAfter - bobBilBefore, amt - settledBefore, "unsettled refunded");
 
         // Request still alive with the settled portion
-        (, uint256 amtAfter, uint256 settledAfter, uint256 owedAfter, bool active) = vault.getRedemptionRequest(reqId);
+        (, uint256 amtAfter, uint256 settledAfter, uint256 owedAfter, bool active,) = vault.getRedemptionRequest(reqId);
         assertTrue(active, "request still alive");
         assertEq(amtAfter, settledBefore, "amount shrunk to settled");
         assertEq(settledAfter, settledBefore, "settled unchanged");

--- a/bil-vault/test/unit/QueueFills.t.sol
+++ b/bil-vault/test/unit/QueueFills.t.sol
@@ -1,0 +1,491 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {BaseTest} from "../helpers/BaseTest.sol";
+import {BILVault} from "../../src/BILVault.sol";
+import {QueueLib} from "../../src/libraries/QueueLib.sol";
+
+/// @title Queue Fills — strict-FIFO early settlement (QUEUE-FILLS-SPEC.md)
+/// @notice Covers the unit matrix: listing lifecycle, the head-first fill
+///         walk with skip semantics, partial fills, races against cancel and
+///         settlement, and the accounting-neutrality invariants (a fill must
+///         never move the exchange rate, totalAssets, idleHollar or
+///         totalReservedHollar).
+contract QueueFillsTest is BaseTest {
+    uint256 internal constant BPS = 10_000;
+
+    address public filler = makeAddr("filler");
+    address public filler2 = makeAddr("filler2");
+    address public operator = makeAddr("operator");
+    address public guardian = makeAddr("guardian");
+
+    struct Snap {
+        uint256 rate;
+        uint256 assets;
+        uint256 idle;
+        uint256 reserved;
+        uint256 supply;
+    }
+
+    function setUp() public override {
+        super.setUp();
+        vm.startPrank(admin);
+        vault.setFillsEnabled(true);
+        vault.grantRole(vault.GUARDIAN_ROLE(), guardian);
+        vm.stopPrank();
+
+        hollar.mint(filler, 1_000_000e18);
+        hollar.mint(filler2, 1_000_000e18);
+        vm.prank(filler);
+        hollar.approve(address(vault), type(uint256).max);
+        vm.prank(filler2);
+        hollar.approve(address(vault), type(uint256).max);
+    }
+
+    // ─── helpers ───
+
+    function _snap() internal view returns (Snap memory s) {
+        s.rate = vault.exchangeRate();
+        s.assets = vault.totalAssets();
+        s.idle = vault.idleHollar();
+        s.reserved = vault.totalReservedHollar();
+        s.supply = vault.totalSupply();
+    }
+
+    /// @dev The headline invariant: fills never touch vault accounting.
+    function _assertVaultNeutral(Snap memory a, Snap memory b) internal pure {
+        assertEq(b.rate, a.rate, "rate moved");
+        assertEq(b.assets, a.assets, "totalAssets moved");
+        assertEq(b.idle, a.idle, "idleHollar moved");
+        assertEq(b.reserved, a.reserved, "totalReservedHollar moved");
+        assertEq(b.supply, a.supply, "totalSupply moved");
+    }
+
+    /// @dev Expected payment for `shares` at `ask`: the exact double-floor
+    ///      the walk uses.
+    function _price(uint256 shares, uint256 ask) internal view returns (uint256) {
+        return (((shares * vault.exchangeRate()) / 1e18) * (BPS - ask)) / BPS;
+    }
+
+    function _list(address user, uint256 requestId, uint32 askBps) internal {
+        vm.prank(user);
+        vault.setFillAsk(requestId, askBps);
+    }
+
+    function _ask(uint256 requestId) internal view returns (uint32 plusOne) {
+        (, , , , , plusOne) = vault.getRedemptionRequest(requestId);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //   LISTING LIFECYCLE
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_setFillAsk_listsAndReprices() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 id = _requestRedeem(bob, vault.balanceOf(bob));
+
+        vm.expectEmit(true, true, false, true, address(vault));
+        emit QueueLib.FillAskSet(id, bob, 100);
+        _list(bob, id, 100);
+        assertEq(_ask(id), 101, "askPlusOne encodes ask+1");
+
+        _list(bob, id, 250); // re-price
+        assertEq(_ask(id), 251);
+    }
+
+    function test_setFillAsk_clearSentinel_isIdempotent() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 id = _requestRedeem(bob, vault.balanceOf(bob));
+        _list(bob, id, 100);
+
+        vm.expectEmit(true, false, false, false, address(vault));
+        emit QueueLib.FillAskCleared(id);
+        _list(bob, id, type(uint32).max);
+        assertEq(_ask(id), 0, "delisted");
+
+        // Clearing again is a no-op, not a revert.
+        _list(bob, id, type(uint32).max);
+        assertEq(_ask(id), 0);
+    }
+
+    function test_setFillAsk_capAndValidation() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 id = _requestRedeem(bob, vault.balanceOf(bob));
+
+        vm.prank(bob);
+        vm.expectRevert(QueueLib.AskTooHigh.selector);
+        vault.setFillAsk(id, 2_001);
+
+        vm.prank(bob);
+        vm.expectRevert(QueueLib.InvalidRequestId.selector);
+        vault.setFillAsk(999, 100);
+
+        // Cancelled request: not listable.
+        vm.prank(bob);
+        vault.cancelRedeem(id);
+        vm.prank(bob);
+        vm.expectRevert(QueueLib.RequestNotActive.selector);
+        vault.setFillAsk(id, 100);
+    }
+
+    function test_setFillAsk_auth() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 id = _requestRedeem(bob, vault.balanceOf(bob));
+
+        vm.prank(alice);
+        vm.expectRevert(QueueLib.NotRequestOwner.selector);
+        vault.setFillAsk(id, 100);
+
+        // ERC-7540 operator may list on the controller's behalf.
+        vm.prank(bob);
+        vault.setOperator(operator, true);
+        vm.prank(operator);
+        vault.setFillAsk(id, 150);
+        assertEq(_ask(id), 151);
+    }
+
+    function test_cancelRedeem_clearsAsk() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 id = _requestRedeem(bob, vault.balanceOf(bob));
+        _list(bob, id, 100);
+
+        vm.expectEmit(true, false, false, false, address(vault));
+        emit QueueLib.FillAskCleared(id);
+        vm.prank(bob);
+        vault.cancelRedeem(id);
+        assertEq(_ask(id), 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //   FULL FILL
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_fillQueue_singleEntry_full() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 shares = vault.balanceOf(bob);
+        uint256 id = _requestRedeem(bob, shares);
+        _list(bob, id, 100); // 1%
+
+        uint256 expectedPay = _price(shares, 100);
+        Snap memory pre = _snap();
+        uint256 bobHollarBefore = hollar.balanceOf(bob);
+        uint256 fillerHollarBefore = hollar.balanceOf(filler);
+
+        vm.expectEmit(true, true, false, true, address(vault));
+        emit QueueLib.RequestFilled(id, bob, expectedPay, shares);
+        vm.prank(filler);
+        (uint256 spent, uint256 received) = vault.fillQueue(type(uint256).max, 0);
+
+        assertEq(spent, expectedPay, "spent = quoted price");
+        assertEq(received, shares, "all pending bought");
+        assertEq(hollar.balanceOf(bob) - bobHollarBefore, expectedPay, "seller paid");
+        assertEq(fillerHollarBefore - hollar.balanceOf(filler), expectedPay, "filler debited");
+        assertEq(vault.balanceOf(filler), shares, "escrow released to filler");
+
+        // Entry fully drained with nothing settled -> deleted, head swept.
+        (, , , , bool active, ) = vault.getRedemptionRequest(id);
+        assertFalse(active, "entry deleted");
+        assertEq(vault.totalQueuedBil(), 0, "queue empty");
+        assertEq(vault.queueHead(), vault.queueTail(), "head swept past hole");
+
+        _assertVaultNeutral(pre, _snap());
+    }
+
+    function test_fillQueue_priceRespectsAsk() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 shares = vault.balanceOf(bob);
+        uint256 id = _requestRedeem(bob, shares);
+        _list(bob, id, 2_000); // max ask: 20%
+
+        vm.prank(filler);
+        (uint256 spent, uint256 received) = vault.fillQueue(type(uint256).max, 0);
+        assertEq(received, shares);
+        assertEq(spent, _price(shares, 2_000));
+        // 20% below NAV, double-floored.
+        assertLe(spent, (shares * vault.exchangeRate() / 1e18) * 8_000 / BPS);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //   PARTIAL FILL
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_fillQueue_partial_thenCompletion() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 shares = vault.balanceOf(bob);
+        uint256 id = _requestRedeem(bob, shares);
+        _list(bob, id, 100);
+
+        // Budget for roughly 40% of the entry.
+        uint256 budget = _price(shares, 100) * 2 / 5;
+        Snap memory pre = _snap();
+
+        vm.prank(filler);
+        (uint256 spent1, uint256 got1) = vault.fillQueue(budget, 0);
+        assertLe(spent1, budget, "never overdraws budget");
+        assertLt(got1, shares, "partial");
+        assertGt(got1, 0);
+
+        // Remainder still queued and still listed at the same ask.
+        (, uint256 bilAmount, uint256 bilSettled, , bool active, ) = vault.getRedemptionRequest(id);
+        assertTrue(active, "entry stays");
+        assertEq(bilAmount - bilSettled, shares - got1, "pending shrank in place");
+        assertEq(_ask(id), 101, "ask persists across partial fill");
+        assertEq(vault.totalQueuedBil(), shares - got1);
+        assertEq(vault.queueHead(), 0, "head does not pass a live entry");
+
+        // A second filler completes it.
+        vm.prank(filler2);
+        (, uint256 got2) = vault.fillQueue(type(uint256).max, 0);
+        assertEq(got1 + got2, shares, "aggregate demand drains the whale");
+        assertEq(vault.totalQueuedBil(), 0);
+
+        _assertVaultNeutral(pre, _snap());
+    }
+
+    function test_fillQueue_partial_exactPaymentRounding() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 shares = vault.balanceOf(bob);
+        uint256 id = _requestRedeem(bob, shares);
+        _list(bob, id, 137); // awkward ask for rounding
+
+        uint256 budget = 3_333e18 + 7; // awkward budget
+        uint256 bobBefore = hollar.balanceOf(bob);
+        vm.prank(filler);
+        (uint256 spent, uint256 got) = vault.fillQueue(budget, 0);
+
+        assertLe(spent, budget, "pay <= budget always");
+        assertEq(spent, _price(got, 137), "pay recomputed from shares");
+        assertEq(hollar.balanceOf(bob) - bobBefore, spent);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //   WALK / SKIP SEMANTICS
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_fillQueue_strictFifo_skipsUnlistedAndUnderpriced() public {
+        _deposit(alice, TEN_THOUSAND_HOLLAR);
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        _deposit(charlie, TEN_THOUSAND_HOLLAR);
+        uint256 r0 = _requestRedeem(alice, vault.balanceOf(alice)); // unlisted
+        uint256 r1 = _requestRedeem(bob, vault.balanceOf(bob));
+        uint256 r2 = _requestRedeem(charlie, vault.balanceOf(charlie));
+        _list(bob, r1, 50); // 0.5%
+        _list(charlie, r2, 200); // 2%
+
+        // Filler demands >= 1%: r0 unlisted (skip), r1 too cheap (skip),
+        // r2 fills. Head must stay pinned before alice's live entry.
+        vm.prank(filler);
+        (, uint256 got) = vault.fillQueue(type(uint256).max, 100);
+        (, , , , bool r2active, ) = vault.getRedemptionRequest(r2);
+        assertFalse(r2active, "r2 filled");
+        (, uint256 r1amount, , , bool r1active, ) = vault.getRedemptionRequest(r1);
+        assertTrue(r1active, "r1 skipped (ask below filler's floor)");
+        assertGt(r1amount, 0);
+        (, , , , bool r0active, ) = vault.getRedemptionRequest(r0);
+        assertTrue(r0active, "r0 untouched");
+        assertEq(vault.queueHead(), 0, "head frozen before live head entry");
+        assertGt(got, 0);
+
+        // Second pass with no floor picks up r1; r0 (unlisted) still safe.
+        vm.prank(filler);
+        vault.fillQueue(type(uint256).max, 0);
+        (, , , , r1active, ) = vault.getRedemptionRequest(r1);
+        assertFalse(r1active, "r1 filled on second pass");
+        (, , , , r0active, ) = vault.getRedemptionRequest(r0);
+        assertTrue(r0active, "unlisted never fillable");
+    }
+
+    function test_fillQueue_fifoOrder_amongListed() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        _deposit(charlie, TEN_THOUSAND_HOLLAR);
+        uint256 r0 = _requestRedeem(bob, vault.balanceOf(bob));
+        uint256 r1 = _requestRedeem(charlie, vault.balanceOf(charlie));
+        _list(bob, r0, 100);
+        _list(charlie, r1, 100);
+
+        // Budget covers only the first entry: strictly the head seller
+        // gets paid, never the later one.
+        (, uint256 r0amount, , , , ) = vault.getRedemptionRequest(r0);
+        // compute before prank — the helper staticcall would consume it
+        uint256 budget = _price(r0amount, 100);
+        vm.prank(filler);
+        vault.fillQueue(budget, 0);
+
+        (, , , , bool r0active, ) = vault.getRedemptionRequest(r0);
+        (, , , , bool r1active, ) = vault.getRedemptionRequest(r1);
+        assertFalse(r0active, "head filled first");
+        assertTrue(r1active, "later entry untouched");
+    }
+
+    function test_fillQueue_iterationCap() public {
+        _deposit(bob, 100_000e18 <= hollar.balanceOf(bob) ? 100_000e18 : hollar.balanceOf(bob));
+        // 51 small requests from one controller, all listed.
+        for (uint256 i; i < 51; i++) {
+            uint256 id = _requestRedeem(bob, 2e18);
+            _list(bob, id, 100);
+        }
+        vm.prank(filler);
+        (, uint256 got) = vault.fillQueue(type(uint256).max, 0);
+        assertEq(got, 50 * 2e18, "work cap: 50 real fills per call");
+
+        vm.prank(filler);
+        (, uint256 got2) = vault.fillQueue(type(uint256).max, 0);
+        assertEq(got2, 2e18, "second call drains the tail");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //   GATES + RACES
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_fillQueue_gates() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 id = _requestRedeem(bob, vault.balanceOf(bob));
+        _list(bob, id, 100);
+
+        // Kill switch.
+        vm.prank(guardian);
+        vault.setFillsEnabled(false);
+        vm.prank(filler);
+        vm.expectRevert(BILVault.FillsDisabled.selector);
+        vault.fillQueue(type(uint256).max, 0);
+
+        // Guardian cannot re-arm; admin can.
+        vm.prank(guardian);
+        vm.expectRevert();
+        vault.setFillsEnabled(true);
+        vm.prank(alice);
+        vm.expectRevert(BILVault.NotAdminOrGuardian.selector);
+        vault.setFillsEnabled(false);
+        vm.prank(admin);
+        vault.setFillsEnabled(true);
+
+        // Pause gates fills like claims.
+        vm.prank(admin);
+        vault.pause();
+        vm.prank(filler);
+        vm.expectRevert("Pausable: paused");
+        vault.fillQueue(type(uint256).max, 0);
+        vm.prank(admin);
+        vault.unpause();
+
+        // Nothing listed -> NothingFilled.
+        _list(bob, id, type(uint32).max);
+        vm.prank(filler);
+        vm.expectRevert(QueueLib.NothingFilled.selector);
+        vault.fillQueue(type(uint256).max, 0);
+    }
+
+    function test_fillQueue_afterCancel_isNothingFilled() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 id = _requestRedeem(bob, vault.balanceOf(bob));
+        _list(bob, id, 100);
+        vm.prank(bob);
+        vault.cancelRedeem(id);
+
+        vm.prank(filler);
+        vm.expectRevert(QueueLib.NothingFilled.selector);
+        vault.fillQueue(type(uint256).max, 0);
+    }
+
+    function test_fillQueue_selfFill_isValueNeutral() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        uint256 shares = vault.balanceOf(bob);
+        uint256 id = _requestRedeem(bob, shares);
+        _list(bob, id, 100);
+
+        vm.prank(bob);
+        hollar.approve(address(vault), type(uint256).max);
+        uint256 hollarBefore = hollar.balanceOf(bob);
+        vm.prank(bob);
+        vault.fillQueue(type(uint256).max, 0);
+
+        // Paid himself: HOLLAR net zero, shares back in his wallet.
+        assertEq(hollar.balanceOf(bob), hollarBefore, "self-fill HOLLAR net zero");
+        assertEq(vault.balanceOf(bob), shares, "shares round-tripped");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //   SETTLED-SLICE ISOLATION (fill never touches settlement)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_fill_ignoresSettledSlice_claimSurvives() public {
+        // Alice's small matured position funds a partial settlement of
+        // bob's much larger request (recipe from PartialRedeemRounding).
+        _deposit(alice, TEN_THOUSAND_HOLLAR);
+        _deposit(bob, 5 * TEN_THOUSAND_HOLLAR);
+        uint256 bobShares = vault.balanceOf(bob);
+        uint256 id = _requestRedeem(bob, bobShares);
+
+        _warpDays(61);
+        _processPositionFull(0); // settles bob's entry partially
+
+        (, uint256 amount, uint256 settled, uint256 owed, , ) = vault.getRedemptionRequest(id);
+        assertGt(settled, 0, "fixture: partially settled");
+        assertGt(amount - settled, 0, "fixture: pending remains");
+
+        _list(bob, id, 100);
+        Snap memory pre = _snap();
+        vm.prank(filler);
+        (, uint256 got) = vault.fillQueue(type(uint256).max, 0);
+        assertEq(got, amount - settled, "fill bought exactly the pending tail");
+
+        // Settled slice untouched and still claimable by BOB, not the filler.
+        (, uint256 amount2, uint256 settled2, uint256 owed2, bool active, ) =
+            vault.getRedemptionRequest(id);
+        assertTrue(active, "entry retained for claim");
+        assertEq(settled2, settled, "bilSettled untouched");
+        assertEq(owed2, owed, "hollarOwed untouched");
+        assertEq(amount2, settled2, "nothing pending left");
+        _assertVaultNeutral(pre, _snap());
+
+        uint256 bobHollar = hollar.balanceOf(bob);
+        vm.prank(bob);
+        uint256 claimed = vault.redeem(settled, bob, bob);
+        assertEq(claimed, owed, "settled claim pays in full");
+        assertEq(hollar.balanceOf(bob) - bobHollar, owed);
+    }
+
+    function test_fill_thenSettle_composes() public {
+        // Fill part of an entry, then let settlement handle the rest —
+        // both operate on `pending` and never double-count.
+        _deposit(alice, TEN_THOUSAND_HOLLAR);
+        _deposit(bob, 2 * TEN_THOUSAND_HOLLAR);
+        uint256 bobShares = vault.balanceOf(bob);
+        uint256 id = _requestRedeem(bob, bobShares);
+        _list(bob, id, 100);
+
+        // Partial fill first.
+        uint256 third = _price(bobShares, 100) / 3;
+        vm.prank(filler);
+        (, uint256 filled) = vault.fillQueue(third, 0);
+        (, uint256 amount, , , , ) = vault.getRedemptionRequest(id);
+        assertEq(amount, bobShares - filled);
+
+        // Then maturity-driven settlement of the remainder.
+        _warpDays(61);
+        _processPositionFull(0);
+        _processPositionFull(1);
+        (, uint256 amount3, uint256 settled3, , , ) = vault.getRedemptionRequest(id);
+        assertEq(settled3, amount3, "remainder fully settled");
+        assertEq(settled3, bobShares - filled, "no double-count");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    //   ADJACENT MACHINERY UNAFFECTED
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function test_fill_improvesWaitEstimateBehind() public {
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        _deposit(charlie, TEN_THOUSAND_HOLLAR);
+        uint256 r0 = _requestRedeem(bob, vault.balanceOf(bob));
+        uint256 r1 = _requestRedeem(charlie, vault.balanceOf(charlie));
+
+        uint256 waitBefore = vault.getEstimatedWaitTime(r1);
+        _list(bob, r0, 100);
+        vm.prank(filler);
+        vault.fillQueue(type(uint256).max, 0);
+
+        // r0 left the queue -> charlie needs less HOLLAR ahead of him.
+        assertLe(vault.getEstimatedWaitTime(r1), waitBefore, "estimate improves");
+    }
+}

--- a/bil-vault/test/unit/QueueGrief.t.sol
+++ b/bil-vault/test/unit/QueueGrief.t.sol
@@ -92,7 +92,7 @@ contract QueueGriefTest is BaseTest {
         _spamCreateAndCancelReverse(bob, 200);
 
         assertEq(vault.queueHead(), 0, "queueHead unchanged (none were at head)");
-        assertEq(vault.getRedemptionQueueLength(), 201, "201 total slots");
+        assertEq(vault.queueTail(), 201, "201 total slots");
 
         // Now mature alice's deposit and process to fill idleHollar.
         _warpDays(61);

--- a/bil-vault/test/unit/Redeem.t.sol
+++ b/bil-vault/test/unit/Redeem.t.sol
@@ -86,7 +86,7 @@ contract RedeemTest is BaseTest {
 
         uint256 requestId = _requestRedeem(alice, redeemAmt);
 
-        (address user, uint256 amount, uint256 settled, , bool active) =
+        (address user, uint256 amount, uint256 settled, , bool active,) =
             vault.getRedemptionRequest(requestId);
 
         assertEq(user, alice);
@@ -116,7 +116,7 @@ contract RedeemTest is BaseTest {
 
         assertEq(id0, 0);
         assertEq(id1, 1);
-        assertEq(vault.getRedemptionQueueLength(), 2);
+        assertEq(vault.queueTail(), 2);
     }
 
     /// @notice Spec: emit RedemptionRequested(requestId, msg.sender, wdclAmount)
@@ -180,7 +180,7 @@ contract RedeemTest is BaseTest {
         assertEq(vault.balanceOf(alice), aliceBefore + redeemAmt, "BIL returned");
         assertEq(vault.totalQueuedBil(), 0, "totalQueuedBil zeroed");
 
-        (, , , , bool active) = vault.getRedemptionRequest(requestId);
+        (, , , , bool active,) = vault.getRedemptionRequest(requestId);
         assertFalse(active, "Request inactive after cancel");
     }
 
@@ -203,7 +203,7 @@ contract RedeemTest is BaseTest {
         // Process queue: Alice fully fulfilled (FIFO), Bob partially
         vault.pokeQueue();
 
-        (, , uint256 bobSettled, , bool bobActive) = vault.getRedemptionRequest(bobRequestId);
+        (, , uint256 bobSettled, , bool bobActive,) = vault.getRedemptionRequest(bobRequestId);
         // Bob should be partially settled if any idle remained after Alice
         if (bobSettled > 0 && bobActive) {
             uint256 remaining = bobBil - bobSettled;
@@ -246,7 +246,7 @@ contract RedeemTest is BaseTest {
 
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 1, "YieldWithdrawalRequested");
     }
 
@@ -257,7 +257,7 @@ contract RedeemTest is BaseTest {
 
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 0, "Still Active before maturity");
     }
 
@@ -270,7 +270,7 @@ contract RedeemTest is BaseTest {
         vault.pokeDecentral(0);
 
         // Approve yield
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
 
         uint256 idleBefore = vault.idleHollar();
@@ -280,7 +280,7 @@ contract RedeemTest is BaseTest {
 
         assertGt(vault.idleHollar(), idleBefore, "Yield received as idle HOLLAR");
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 3, "PrincipalWithdrawalRequested (skips through YieldClaimed)");
     }
 
@@ -294,7 +294,7 @@ contract RedeemTest is BaseTest {
 
         vault.pokeDecentral(0); // should no-op (try/catch)
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 1, "Still YieldWithdrawalRequested when not approved");
     }
 
@@ -305,7 +305,7 @@ contract RedeemTest is BaseTest {
 
         // Walk through to PrincipalWithdrawalRequested
         vault.pokeDecentral(0);
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(0);
 
@@ -319,7 +319,7 @@ contract RedeemTest is BaseTest {
 
         assertGt(vault.idleHollar(), idleBefore, "Principal received as idle HOLLAR");
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 4, "Redeemed");
     }
 
@@ -341,7 +341,7 @@ contract RedeemTest is BaseTest {
 
         _processPositionFull(0);
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 4, "Redeemed");
 
         uint256 idle = vault.idleHollar();
@@ -360,7 +360,7 @@ contract RedeemTest is BaseTest {
         _warpDays(61);
 
         vault.pokeDecentral(0);
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
 
         uint256 idleBefore = vault.idleHollar();
@@ -414,11 +414,11 @@ contract RedeemTest is BaseTest {
         _warpDays(51);
 
         vault.pokeDecentral(0);
-        (, , , , , uint8 s0) = vault.getPosition(0);
+        (, , , , , uint8 s0,,,) = vault.getPosition(0);
         assertEq(s0, 1, "Position 0 advances (mature)");
 
         vault.pokeDecentral(1);
-        (, , , , , uint8 s1) = vault.getPosition(1);
+        (, , , , , uint8 s1,,,) = vault.getPosition(1);
         assertEq(s1, 0, "Position 1 stays Active (not mature)");
     }
 
@@ -431,7 +431,7 @@ contract RedeemTest is BaseTest {
         vm.prank(keeper);
         vault.pokeDecentral(0);
 
-        (, , , , , uint8 state) = vault.getPosition(0);
+        (, , , , , uint8 state,,,) = vault.getPosition(0);
         assertEq(state, 1, "Keeper can advance position");
     }
 
@@ -619,7 +619,7 @@ contract RedeemTest is BaseTest {
 
         vault.pokeQueue();
 
-        (, uint256 principal, uint256 apyWad, , , uint8 state) = vault.getPosition(posIdx);
+        (, uint256 principal, uint256 apyWad, , , uint8 state,,,) = vault.getPosition(posIdx);
         assertApproxEqRel(principal, idle, 0.01e18, "Reinvested principal = idle");
         assertEq(apyWad, APY_18_PERCENT, "APY from pool");
         assertEq(state, 0, "Active");
@@ -703,7 +703,7 @@ contract RedeemTest is BaseTest {
 
         vault.pokeQueue();
 
-        (, uint256 principal, , , , ) = vault.getPosition(posIdx);
+        (, uint256 principal, , , ,,,,) = vault.getPosition(posIdx);
         assertEq(principal, TEN_THOUSAND_HOLLAR, "Reinvest capped at tvlCap");
 
         // Remainder stays as idle
@@ -880,14 +880,14 @@ contract RedeemTest is BaseTest {
         uint256 aliceBil = _deposit(alice, TEN_THOUSAND_HOLLAR);
 
         // Getters on empty queue
-        assertEq(vault.getTotalQueuedBil(), 0);
-        assertEq(vault.getIdleHollar(), 0);
+        assertEq(vault.totalQueuedBil(), 0);
+        assertEq(vault.idleHollar(), 0);
         assertEq(vault.getRedemptionQueuePending(), 0);
-        assertEq(vault.getQueueHead(), 0);
+        assertEq(vault.queueHead(), 0);
 
         // After queue entry
         _requestRedeem(alice, aliceBil / 4);
-        assertGt(vault.getTotalQueuedBil(), 0);
+        assertGt(vault.totalQueuedBil(), 0);
         assertEq(vault.getRedemptionQueuePending(), 1);
     }
 

--- a/bil-vault/test/unit/RedemptionQueue.t.sol
+++ b/bil-vault/test/unit/RedemptionQueue.t.sol
@@ -39,13 +39,13 @@ contract RedemptionQueueTest is BaseTest {
     function test_requestRedeem_createsQueueEntry() public {
         uint256 bil = _deposit(alice, TEN_THOUSAND_HOLLAR);
 
-        assertEq(vault.getRedemptionQueueLength(), 0, "Queue should start empty");
+        assertEq(vault.queueTail(), 0, "Queue should start empty");
 
         _requestRedeem(alice, bil / 2);
 
-        assertEq(vault.getRedemptionQueueLength(), 1, "Queue should have 1 entry");
+        assertEq(vault.queueTail(), 1, "Queue should have 1 entry");
 
-        (address user, uint256 bilAmount, uint256 bilSettled, , bool active) =
+        (address user, uint256 bilAmount, uint256 bilSettled, , bool active,) =
             vault.getRedemptionRequest(0);
         assertEq(user, alice, "Request user should be Alice");
         assertEq(bilAmount, bil / 2, "Request amount should match");
@@ -89,7 +89,7 @@ contract RedemptionQueueTest is BaseTest {
         assertEq(vault.totalQueuedBil(), 0, "totalQueuedBil should be 0 after cancel");
 
         // Request should be inactive
-        (, , , , bool active) = vault.getRedemptionRequest(requestId);
+        (, , , , bool active,) = vault.getRedemptionRequest(requestId);
         assertFalse(active, "Request should be inactive after cancel");
     }
 
@@ -283,8 +283,8 @@ contract RedemptionQueueTest is BaseTest {
         _claimAll(alice);
 
         // Request 0 is inactive (cancelled), request 1 should be settled+claimed (deleted)
-        (, , , , bool active0) = vault.getRedemptionRequest(request0);
-        (, , , , bool active1) = vault.getRedemptionRequest(request1);
+        (, , , , bool active0,) = vault.getRedemptionRequest(request0);
+        (, , , , bool active1,) = vault.getRedemptionRequest(request1);
         assertFalse(active0, "Request 0 should remain inactive");
         assertFalse(active1, "Request 1 should be settled+claimed (deleted)");
 

--- a/bil-vault/test/unit/Reinvest.t.sol
+++ b/bil-vault/test/unit/Reinvest.t.sol
@@ -35,7 +35,7 @@ contract ReinvestTest is BaseTest {
         assertLt(idleAfter, idleBefore, "idleHollar should decrease after reinvest");
 
         // New position should have the reinvested amount as principal
-        (, uint256 principal, , , , uint8 state) = vault.getPosition(positionCountBefore);
+        (, uint256 principal, , , , uint8 state,,,) = vault.getPosition(positionCountBefore);
         assertApproxEqRel(
             principal,
             idleBefore,
@@ -150,7 +150,7 @@ contract ReinvestTest is BaseTest {
         vault.pokeQueue();
 
         // New position principal should be capped at tvlCap
-        (, uint256 principal, , , , ) = vault.getPosition(posCountBefore);
+        (, uint256 principal, , , ,,,,) = vault.getPosition(posCountBefore);
         assertEq(principal, TEN_THOUSAND_HOLLAR, "Reinvested principal should be capped at TVL cap");
 
         // idle should still have remainder (the yield portion beyond the cap)

--- a/bil-vault/test/unit/YieldRequestWindow.t.sol
+++ b/bil-vault/test/unit/YieldRequestWindow.t.sol
@@ -14,7 +14,7 @@ import {BILVault} from "../../src/BILVault.sol";
 contract YieldRequestWindowTest is BaseTest {
     /// @dev Per-position pendingYield via the public struct getter (last tuple element).
     function _pendingYield(uint256 idx) internal view returns (uint256 py) {
-        (,,,,,,,, py) = vault.positions(idx);
+        (,,,,,,, py,) = vault.getPosition(idx);
     }
 
     /// @dev Bring position 0 to YieldWithdrawalRequested.
@@ -80,7 +80,7 @@ contract YieldRequestWindowTest is BaseTest {
         // existing comment in pokeDecentral notes this surplus path
         // explicitly). Tolerate the upward rate movement; assert only that
         // the rate did not DROP — that's the bug the original test guarded.
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(0);
 
@@ -122,7 +122,7 @@ contract YieldRequestWindowTest is BaseTest {
         assertEq(vault.yieldRateSum(), 0, "bucket yield cleared at request");
 
         // Execute
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(0);
 
@@ -181,7 +181,7 @@ contract YieldRequestWindowTest is BaseTest {
         rPrev = rDelayed;
 
         // Execute (T3)
-        (uint256 tokenId, , , , , ) = vault.getPosition(0);
+        (uint256 tokenId, , , , ,,,,) = vault.getPosition(0);
         pool.approveYieldWithdrawal(tokenId);
         vault.pokeDecentral(0);
         uint256 rExecute = vault.exchangeRate();


### PR DESCRIPTION
Implements the accepted queue-fills design (bil-vault/QUEUE-FILLS-PLAN.md §9, spec in QUEUE-FILLS-SPEC.md): third parties buy queued BIL strictly head-first at seller-chosen discounts, so exiters get paid early without touching vault liquidity or FIFO settlement order.

**Mechanics**
- `setFillAsk(requestId, askBps)` → controller/operator lists the pending portion (≤20% cap, `type(uint32).max` sentinel delists)
- `fillQueue(maxHollarIn, minAskBps)` → filler's HOLLAR walks from queueHead paying each listed entry's controller `pending × rate × (1 − ask)`; escrowed hDCL goes to the filler; last entry fills partially when the budget runs short
- live-but-unlisted (or under-ask) entries are skipped, never stopped at → no head-of-queue veto; head never passes a live entry
- settled slices (`bilSettled`/`hollarOwed`) untouched → a fill is a cancel with a different share destination, not a settlement
- accounting-neutral by construction: `exchangeRate` / `totalAssets` / `idleHollar` / `totalReservedHollar` provably unchanged across any fill (asserted in tests)
- ships disabled: `fillsEnabled=false`; admin arms, guardian can kill

**EIP-170** (vault had 313 bytes of headroom, feature costs ~2.4KB)
- listing/cancel/fill logic + all events moved into QueueLib (delegatecall preserves msg.sender)
- `cancelRedeem` body → lib (vault keeps only the refund `_transfer`)
- `redemptionQueue`/`positions` internalized; `getRedemptionRequest` gains `askPlusOne`, `getPosition` gains `yieldCapped`/`pendingYield`/`yieldStartTime` (appended → old static-decode consumers unaffected)
- dropped redundant explicit getters (`getTotalQueuedBil`/`getIdleHollar`/`getRedemptionQueueLength`/`getQueueHead`) — public vars are the getters; keeper migrated to `queueTail`
- result: vault 24,443 bytes (133 spare), storage append-only (`fillAskPlusOne` + `fillsEnabled`, gap 47→45, no reinitializer)

**Tests**: 391 green — 18 new unit cases (listing lifecycle, skip semantics, partial fills + rounding, cancel/settle races, settled-slice isolation, iteration cap, self-fill neutrality, kill switch) + `setFillAsk`/`fillQueue` actions fuzzing the invariant suite.

**Not in scope**: UI/indexer/keeper filler module, audit addendum, upgrade ref — per the spec's delivery checklist this lands post-mainnet-launch.