### PR TITLE
bil-vault: fix settled-share exchange-rate dilution (Pashov High)

### DIFF
--- a/bil-vault/src/BILVault.sol
+++ b/bil-vault/src/BILVault.sol
@@ -435,12 +435,39 @@ contract BILVault is
             totalReservedHollar;
     }
 
-    /// @notice Current BIL/HOLLAR exchange rate (18 decimals)
+    /// @notice HOLLAR value of the ACTIVE share pool — total assets minus the
+    ///         reserved HOLLAR backing settled (exited) claims.
+    /// @dev    Reserved HOLLAR is a fixed liability owed to settled redeemers,
+    ///         not value available to active shareholders.
+    function _activeAssets() internal view returns (uint256) {
+        uint256 total = totalAssets();
+        // reserved is always ≤ total (it's a summed component of totalAssets),
+        // but clamp defensively.
+        return total > totalReservedHollar ? total - totalReservedHollar : 0;
+    }
+
+    /// @notice Active (non-settled) share supply. Settled shares are exited —
+    ///         they carry a fixed claim and must not share in active yield.
+    ///         Dead shares are active, so this stays ≥ DEAD_SHARES once
+    ///         bootstrapped (the rate denominator can't hit zero).
+    function _activeSupply() internal view returns (uint256) {
+        uint256 supply = totalSupply();
+        return supply > totalSettledBil ? supply - totalSettledBil : 0;
+    }
+
+    /// @notice Current BIL/HOLLAR exchange rate (18 decimals) — the value of
+    ///         one ACTIVE share.
+    /// @dev    Prices active shares against active assets only; settled shares
+    ///         and their reserved HOLLAR are excluded (Pashov High —
+    ///         settled-share dilution). Because a share is settled at exactly
+    ///         this rate (hollarOwed = shares × rate), settlement is
+    ///         rate-neutral: removing (shares, shares×rate) from the active
+    ///         pool leaves the ratio unchanged.
     /// @return Rate in WAD (1e18 = 1:1)
     function exchangeRate() public view returns (uint256) {
-        uint256 supply = totalSupply();
-        if (supply == 0) return WAD;
-        return (totalAssets() * WAD) / supply;
+        uint256 activeSupply = _activeSupply();
+        if (activeSupply == 0) return WAD;
+        return (_activeAssets() * WAD) / activeSupply;
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -663,6 +690,7 @@ contract BILVault is
 
         _burn(address(this), shares);
         totalQueuedBil -= shares;
+        totalSettledBil -= shares; // settled shares leaving supply on claim
         totalReservedHollar -= assets;
         hollar.safeTransfer(receiver, assets);
 
@@ -684,6 +712,7 @@ contract BILVault is
 
         _burn(address(this), shares);
         totalQueuedBil -= shares;
+        totalSettledBil -= shares; // settled shares leaving supply on claim
         totalReservedHollar -= assets;
         hollar.safeTransfer(receiver, assets);
 
@@ -964,13 +993,16 @@ contract BILVault is
             if (assets <= DEAD_SHARES) revert DepositTooSmall();
             shares = assets - DEAD_SHARES;
         } else {
-            uint256 totalA = totalAssets();
-            // Catastrophic state: shares exist but no backing. Refuse to
-            // deposit at a zero rate — the depositor would receive no BIL
-            // and lose their HOLLAR. Solidity 0.8+ would panic on the
-            // division below; this gives a clear revert reason instead.
-            if (totalA == 0) revert VaultEmpty();
-            shares = (assets * supply) / totalA;
+            // Mint against the ACTIVE pool — settled shares and their
+            // reserved HOLLAR are excluded so a new depositor pays the true
+            // active rate, not a rate diluted by lingering settled claims.
+            uint256 activeSupply = _activeSupply();
+            uint256 activeA = _activeAssets();
+            // Catastrophic state: active shares exist but no active backing.
+            // Refuse to deposit at a zero rate — the depositor would receive
+            // no BIL and lose their HOLLAR.
+            if (activeA == 0 || activeSupply == 0) revert VaultEmpty();
+            shares = (assets * activeSupply) / activeA;
             if (shares == 0) revert DepositTooSmall();
         }
     }
@@ -1012,18 +1044,18 @@ contract BILVault is
     /// @notice Convert HOLLAR → hDCL at the current rate (no fees, no
     ///         first-deposit dust). For empty supply, returns 1:1.
     function convertToShares(uint256 assets) public view returns (uint256) {
-        uint256 supply = totalSupply();
-        if (supply == 0) return assets;
-        uint256 totalA = totalAssets();
-        if (totalA == 0) return 0;
-        return (assets * supply) / totalA;
+        uint256 activeSupply = _activeSupply();
+        if (activeSupply == 0) return assets; // fresh/empty active pool → 1:1
+        uint256 activeA = _activeAssets();
+        if (activeA == 0) return 0;
+        return (assets * activeSupply) / activeA;
     }
 
-    /// @notice Convert hDCL → HOLLAR at the current rate.
+    /// @notice Convert hDCL → HOLLAR at the current (active) rate.
     function convertToAssets(uint256 shares) public view returns (uint256) {
-        uint256 supply = totalSupply();
-        if (supply == 0) return shares;
-        return (shares * totalAssets()) / supply;
+        uint256 activeSupply = _activeSupply();
+        if (activeSupply == 0) return shares;
+        return (shares * _activeAssets()) / activeSupply;
     }
 
     /// @notice Max HOLLAR `receiver` can deposit right now.
@@ -1072,15 +1104,15 @@ contract BILVault is
     /// @notice Preview how much HOLLAR is needed to mint exactly `shares` hDCL.
     /// @dev    Rounds up to favor the vault — mint will pull at least this much.
     function previewMint(uint256 shares) public view returns (uint256 assets) {
-        uint256 supply = totalSupply();
-        if (supply == 0) {
+        uint256 activeSupply = _activeSupply();
+        if (activeSupply == 0) {
             // First-deposit dust: caller must overpay DEAD_SHARES wei to
             // mint `shares` to themselves while DEAD_SHARES go to 0xdead.
             return shares + DEAD_SHARES;
         }
-        uint256 totalA = totalAssets();
-        // ceil(shares * totalA / supply)
-        return (shares * totalA + supply - 1) / supply;
+        uint256 activeA = _activeAssets();
+        // ceil(shares * activeA / activeSupply)
+        return (shares * activeA + activeSupply - 1) / activeSupply;
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -1109,21 +1141,23 @@ contract BILVault is
             if (hollarAmount <= DEAD_SHARES) revert DepositTooSmall();
             return hollarAmount - DEAD_SHARES;
         }
-        uint256 assets = totalAssets();
-        // Catastrophic state: shares exist but no backing. `deposit` would
-        // revert with VaultEmpty before the divide; mirror that here.
-        if (assets == 0) revert VaultEmpty();
-        bilAmount = (hollarAmount * supply) / assets;
+        uint256 activeSupply = _activeSupply();
+        uint256 activeA = _activeAssets();
+        // Catastrophic state: active shares exist but no active backing.
+        // `deposit` would revert with VaultEmpty before the divide; mirror it.
+        if (activeA == 0 || activeSupply == 0) revert VaultEmpty();
+        bilAmount = (hollarAmount * activeSupply) / activeA;
         if (bilAmount == 0) revert DepositTooSmall();
     }
 
-    /// @notice Preview the HOLLAR value of a BIL redemption at current rate
+    /// @notice Preview the HOLLAR value of a BIL redemption at the current
+    ///         (active) rate.
     function previewRedeem(
         uint256 bilAmount
     ) external view returns (uint256 hollarAmount) {
-        uint256 supply = totalSupply();
-        if (supply == 0) return 0;
-        return (bilAmount * totalAssets()) / supply;
+        uint256 activeSupply = _activeSupply();
+        if (activeSupply == 0) return 0;
+        return (bilAmount * _activeAssets()) / activeSupply;
     }
 
     /// @notice ERC-4626 sync withdraw preview — async-only vault returns 0.
@@ -1516,6 +1550,9 @@ contract BILVault is
         // storage-write surface stays explicit at the call boundary.
         idleHollar -= hollarUsed;
         totalReservedHollar += hollarUsed;
+        // Shares just rate-locked join the settled (exited) pool — excluded
+        // from the active exchange rate from here until claim burns them.
+        totalSettledBil += bilLocked;
     }
 
     /// @dev Advance positionHead past redeemed positions
@@ -1635,10 +1672,22 @@ contract BILVault is
     /// @dev Min-heap of packed (maturityTime, positionIndex) entries.
     uint256[] private _maturityHeap;
 
+    /// @notice Aggregate hDCL across all requests' `bilSettled` (rate-locked,
+    ///         awaiting claim). Settled shares are economically exited — they
+    ///         carry a fixed HOLLAR claim (`hollarOwed`, held in
+    ///         `totalReservedHollar`) and no longer earn yield — but they
+    ///         remain in `totalSupply()` until claim burns them. Excluding
+    ///         them (and their reserved HOLLAR) from the exchange-rate math
+    ///         is what keeps the rate a pure ACTIVE-share rate: without this,
+    ///         lingering settled shares blend a fixed claim against still-
+    ///         accruing active shares and depress the rate for active holders
+    ///         (Pashov High — settled-share dilution).
+    uint256 public totalSettledBil;
+
     // ═══════════════════════════════════════════════════════════════════════
     //                         STORAGE GAP
     // ═══════════════════════════════════════════════════════════════════════
 
     /// @dev Reserved storage slots for future upgrades.
-    uint256[47] private __gap;
+    uint256[46] private __gap;
 }

--- a/bil-vault/test/invariant/InvariantVault.t.sol
+++ b/bil-vault/test/invariant/InvariantVault.t.sol
@@ -249,6 +249,20 @@ contract InvariantVaultTest is Test {
         );
     }
 
+    /// @notice totalSettledBil == sum of bilSettled across all requests, and
+    ///         never exceeds totalSupply (settled shares are a subset of
+    ///         escrowed shares). Underpins the active-share exchange rate.
+    function invariant_totalSettledBilAccurate() public view {
+        uint256 tail = vault.getRedemptionQueueLength();
+        uint256 sum = 0;
+        for (uint256 i = 0; i < tail; i++) {
+            (address u, , uint256 settled, , ) = vault.getRedemptionRequest(i);
+            if (u != address(0)) sum += settled;
+        }
+        assertEq(vault.totalSettledBil(), sum, "INV-13: totalSettledBil mismatch");
+        assertLe(vault.totalSettledBil(), vault.totalSupply(), "settled exceeds supply");
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
     //          ACCOUNTING INVARIANT 12: HOLLAR backing
     // ═══════════════════════════════════════════════════════════════════════

--- a/bil-vault/test/unit/SettledShareDilution.t.sol
+++ b/bil-vault/test/unit/SettledShareDilution.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.22;
+
+import {BaseTest} from "../helpers/BaseTest.sol";
+import {BILVault} from "../../src/BILVault.sol";
+
+/// @title PoC — Pashov High: settled shares dilute the active exchange rate
+/// @notice The finding assumes active shares keep earning while settled shares
+///         are fixed. This vault caps Decentral yield at each position's
+///         maturity (H-01 fix), so an active position only keeps accruing
+///         until IT matures. This test builds the strongest case for the
+///         finding: an active holder (bob) whose position is STILL accruing
+///         AFTER the attacker's request has settled, and measures whether the
+///         blended exchangeRate() is depressed below the true active rate.
+contract SettledShareDilutionTest is BaseTest {
+    address public attacker = makeAddr("attacker");
+
+    function setUp() public override {
+        super.setUp();
+        hollar.mint(attacker, 1_000_000e18);
+        vm.prank(attacker);
+        hollar.approve(address(vault), type(uint256).max);
+    }
+
+    function test_stagger_settledLingers_whileActiveStillAccrues() public {
+        // ── phase 1: attacker gets settled shares, funded by a matured pos ──
+        _deposit(attacker, TEN_THOUSAND_HOLLAR);        // position 0
+        uint256 reqId = _requestRedeem(attacker, vault.balanceOf(attacker));
+        _deposit(charlie, TEN_THOUSAND_HOLLAR);         // position 1, funds settlement
+
+        _warpDays(61);                                  // pos 0 & 1 mature
+        _processPositionFull(0);                        // clear backlog: pos 0
+        _processPositionFull(1);                        // clear backlog: pos 1 -> idle
+        vault.pokeQueue();                              // settle attacker at rate_settle
+
+        (, , uint256 settled, uint256 owed, ) = vault.getRedemptionRequest(reqId);
+        assertGt(settled, 0, "attacker settled");
+        emit log_named_decimal_uint("settled shares    ", settled, 18);
+        emit log_named_decimal_uint("hollarOwed (fixed)", owed, 18);
+        emit log_named_decimal_uint("rate @ settle     ", vault.exchangeRate(), 18);
+
+        // Backlog is now clear (0 & 1 redeemed) so bob CAN deposit.
+        // ── phase 2: bob opens a fresh active position that keeps accruing ──
+        _deposit(bob, TEN_THOUSAND_HOLLAR);             // position 2, fresh
+        _warpDays(30);                                  // < 60d maturity: still accruing
+
+        uint256 reported = vault.exchangeRate();
+        uint256 activeAssets = vault.totalAssets() - vault.totalReservedHollar();
+        uint256 activeSupply = vault.totalSupply() - settled;
+        uint256 trueRate = (activeAssets * 1e18) / activeSupply;
+
+        emit log_named_decimal_uint("reported rate     ", reported, 18);
+        emit log_named_decimal_uint("true active rate  ", trueRate, 18);
+
+        // FIX: exchangeRate() now prices the ACTIVE pool only, so the
+        // reported rate equals the true active rate (±1 wei rounding).
+        assertApproxEqAbs(reported, trueRate, 2, "reported must track true active rate");
+
+        // And a fresh deposit is quoted at the true active rate — no free
+        // extra shares skimmed from active holders.
+        uint256 sharesQuoted = vault.previewDeposit(1_000e18);
+        uint256 sharesAtTrue = (1_000e18 * 1e18) / trueRate;
+        assertApproxEqRel(sharesQuoted, sharesAtTrue, 1e12, "deposit quote at true active rate");
+    }
+}
+
+// Standalone round-trip in a second file-scope contract would duplicate setup;
+// instead re-run the extraction inline here.
+contract SettledShareExtractionTest is BaseTest {
+    address public attacker = makeAddr("attacker");
+
+    function setUp() public override {
+        super.setUp();
+        hollar.mint(attacker, 2_000_000e18);
+        vm.prank(attacker);
+        hollar.approve(address(vault), type(uint256).max);
+    }
+
+    function test_roundTripProfitAndActiveHolderLoss() public {
+        // attacker acquires lingering settled shares (funded by a matured pos)
+        _deposit(attacker, TEN_THOUSAND_HOLLAR);
+        uint256 reqId = _requestRedeem(attacker, vault.balanceOf(attacker));
+        _deposit(charlie, TEN_THOUSAND_HOLLAR);
+        _warpDays(61);
+        _processPositionFull(0);
+        _processPositionFull(1);
+        vault.pokeQueue();
+        (, , uint256 settled, uint256 owed, ) = vault.getRedemptionRequest(reqId);
+
+        // bob: honest active holder, fresh position still accruing
+        _deposit(bob, TEN_THOUSAND_HOLLAR);
+        _warpDays(30);
+
+        // bob's fair value at the TRUE active rate, pre-attack
+        uint256 aA = vault.totalAssets() - vault.totalReservedHollar();
+        uint256 aS = vault.totalSupply() - settled;
+        uint256 bobFairBefore = (vault.balanceOf(bob) * aA) / aS;
+
+        // ── attack: deposit at depressed rate, then claim to pop the rate ──
+        uint256 hBefore = hollar.balanceOf(attacker);
+        vm.prank(attacker);
+        uint256 fresh = vault.deposit(100_000e18, attacker);
+        vm.prank(attacker);
+        vault.redeem(settled, attacker, attacker); // burns settled, removes reserve
+
+        // mark fresh shares at post-claim rate (attacker can exit via pool/queue at this rate)
+        uint256 freshValue = (fresh * vault.exchangeRate()) / 1e18;
+        uint256 hAfter = hollar.balanceOf(attacker);
+        // net HOLLAR the attacker put in = (deposit) - (settled claim received)
+        uint256 netIn = hBefore - hAfter;
+        int256 profit = int256(freshValue) - int256(netIn);
+
+        emit log_named_decimal_uint("settled claim (owed)", owed, 18);
+        emit log_named_decimal_uint("net HOLLAR in        ", netIn, 18);
+        emit log_named_decimal_uint("fresh shares value   ", freshValue, 18);
+        emit log_named_decimal_int("ATTACKER PROFIT      ", profit, 18);
+
+        uint256 bobFairAfter = (vault.balanceOf(bob) * vault.exchangeRate()) / 1e18;
+        emit log_named_decimal_uint("bob fair before      ", bobFairBefore, 18);
+        emit log_named_decimal_uint("bob fair after       ", bobFairAfter, 18);
+        if (bobFairBefore > bobFairAfter) {
+            emit log_named_decimal_uint("BOB LOSS             ", bobFairBefore - bobFairAfter, 18);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the Pashov High "settled shares dilute the active exchange rate."

## Root cause
Settlement records `bilSettled`/`hollarOwed` without burning shares (burn happens on claim). The rate-locked reserved HOLLAR sits in `totalAssets()` earning nothing while the settled shares stay in `totalSupply()`. `exchangeRate()` divided one by the other, blending a fixed claim against still-accruing active shares → the reported rate drifts below the true active rate whenever settled shares linger unclaimed and another position is still accruing. New depositors mint at the depressed rate at active holders' expense.

## Confirmed, then fixed (PoC in `test/unit/SettledShareDilution.t.sol`)
- synchronized maturities → **0 bps** (yield caps at maturity — a mitigation the finding's model missed)
- staggered (active position still accruing after settlement) → **52 bps depression**, real value transfer (an honest active holder lost 44 HOLLAR in the round-trip test)
- **after the fix**: reported rate == true active rate to ±1 wei; the same round trip nets the attacker 0 markup and the active holder loses 6 attowei (rounding dust)

Magnitude was bounded (≈ `active_yield_since_settlement × settled_fraction`, capped by the ~60-day maturity), so I'd have rated the underlying issue Medium — but it's a persistent passive leak (auto-claim is opt-in, so lingering settled shares are the normal state), and the fix is cheap and clean.

## Fix
Price the **active** pool only:
- new `totalSettledBil` (Σ `bilSettled`), maintained: `+= bilLocked` on settle, `-= shares` on claim (redeem + withdraw)
- `_activeAssets() = totalAssets − totalReservedHollar`, `_activeSupply() = totalSupply − totalSettledBil`
- `exchangeRate` / `convertToShares` / `convertToAssets` / `previewMint` / `previewDeposit` / `previewRedeem` / deposit-share math route through the active values
- `totalAssets()` unchanged (ERC-4626 semantic — still reports all AUM); TVL-cap checks unchanged
- settlement stays rate-neutral by construction (a share settles at exactly the active rate, so removing `(shares, shares×rate)` leaves the ratio fixed); DEAD_SHARES keep the active denominator ≥ 1000

## Storage / upgrade
`totalSettledBil` appended before `__gap` (47→46) — append-only, upgrade-safe vs the lark deploy. No reinitializer (genesis value 0 is correct). Vault 24,326 bytes (250 spare).

## Tests
375 green (373 existing unchanged — the rate is identical when no settled shares linger). New: 3-case PoC + `invariant_totalSettledBilAccurate` (Σ bilSettled == totalSettledBil ≤ totalSupply, 12,800 fuzzed calls).

Note: queue fills (money-market#50) transact at `exchangeRate()`, so they inherit this correction automatically — this should land before/with that upgrade.